### PR TITLE
Point at Bevy main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,18 +459,16 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bevy"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3ee8652fe0577fd8a99054e147740850140d530be8e044a9be4e23a3e8a24"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
 name = "bevy_a11y"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6702a82db1b383641fc7c503451847cdafb57076c203cd3bfe549d3eeef474c3"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -481,18 +479,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_android"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b2d9435e9fe8d7107bb795a6140277872ad5b992cb3934f8d28cfd11040f6f"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "android-activity",
 ]
 
 [[package]]
 name = "bevy_animation"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaf3ea6d435f4736b3deb60958270443501f5795c7964b1b504abd3be970b4f"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_animation_macros",
  "bevy_app",
@@ -523,9 +519,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d577eae7246a1cda461df1b63188619fc6a3c619adba2a8e5a79e9aa51f64671"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -534,9 +529,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_anti_alias"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15820535cc88bc280f55635eb3ea58df2703a434a0cc2343472eaa7e607fb27b"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -556,9 +550,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fc5dfe9d1d9b8233e1878353b5e66a3f5910c2131d3abf68f9a4116b2d433"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -579,17 +572,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357787dbfaba3f73fd185e15d6df70605bddaa774f2ebbcab1aaa031f21fb6c2"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "async-broadcast",
+ "async-channel",
  "async-fs",
  "async-lock",
  "atomicow",
  "bevy_android",
  "bevy_app",
  "bevy_asset_macros",
+ "bevy_diagnostic",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
@@ -604,8 +598,8 @@ dependencies = [
  "either",
  "futures-io",
  "futures-lite",
+ "futures-util",
  "js-sys",
- "parking_lot",
  "ron",
  "serde",
  "stackfuture",
@@ -619,9 +613,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa09271d4ca0bf31fda3a9ad57273775d448a05c4046d9367f71d29968d85b4"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -631,9 +624,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79e56e072001524100b00e38cfdea302d9fdabbff48109fc67b528b27a237bb"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -649,9 +641,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_camera"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af1d5a57fde6e577e7b1db58996afb381618294be75a37b3070a20d309678b0"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -675,9 +666,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_color"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49504fac6b9897f03b4bdc0189c04ef1ba0a9b37926343aa520a71619e90e116"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_math",
  "bevy_reflect",
@@ -691,9 +681,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af7e735685a652a8dba41b886f1330faeb57d4c61398917b7e49b09a7a1c3c1"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -720,9 +709,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9396b256b366a43d7f61d1f230cdab0a512fb4712cbf7d688f3d6fce4c5ea8a"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -731,9 +719,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cdb0ed0c8423570fbbb7c4fc2719a203dd40928fefff45f76ef0889685a446"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "atomic-waker",
  "bevy_app",
@@ -749,9 +736,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dd5229dd00d00e70ac6b2fc0a139961252f6ce07d3d268cfcac0da86d5bde4"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "arrayvec",
  "bevy_ecs_macros",
@@ -777,9 +763,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d83bdd2285af4867e76c691406e0a4b55611b583d0c45b6ac7bcec1b45fd48"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -789,9 +774,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7179e985f3f1b99265cb87fe194db3b00aee8e2914888d621ff9826e1417ee19"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -799,9 +783,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a39dd8fdfe93314d47355ab3c58da40b648908a368bc536872f75fad4e8f3755"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -815,38 +798,27 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebb9e3ca4938b48e5111151ce4b08f0e6fc207b854db08fa2d8de15ecabe8f8"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
- "bevy_core_pipeline",
  "bevy_ecs",
  "bevy_gizmos_macros",
- "bevy_image",
  "bevy_light",
  "bevy_math",
- "bevy_mesh",
- "bevy_pbr",
  "bevy_reflect",
- "bevy_render",
- "bevy_shader",
- "bevy_sprite_render",
  "bevy_time",
  "bevy_transform",
  "bevy_utils",
- "bytemuck",
- "tracing",
 ]
 
 [[package]]
 name = "bevy_gizmos_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c4b3c3aac86f0db85d4f708883ebdc735c3f88ac5b84c033874fcdd3540a9d"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -854,10 +826,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_gizmos_render"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
+dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_camera",
+ "bevy_core_pipeline",
+ "bevy_ecs",
+ "bevy_gizmos",
+ "bevy_image",
+ "bevy_math",
+ "bevy_mesh",
+ "bevy_pbr",
+ "bevy_render",
+ "bevy_shader",
+ "bevy_sprite_render",
+ "bevy_transform",
+ "bevy_utils",
+ "bytemuck",
+ "tracing",
+]
+
+[[package]]
 name = "bevy_gltf"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3479fbaf897320a3ee30c1626b4a1bee0be874ca27699c3b2f3494891d103d9b"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "base64",
  "bevy_animation",
@@ -890,9 +885,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_image"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d546bbe2486bfa14971517e7ef427a9384749817c201d3afc60de0325cf52f11"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -919,9 +913,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca955b99f4dc2059e9c8574f8d95a5dd5002809fda80d062a94a553c571a467"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -936,16 +929,17 @@ dependencies = [
 
 [[package]]
 name = "bevy_input_focus"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4d1d0e833e31beba1f28a77152b35f946e8c45df364ec4969d58788ab9de7f"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
+ "bevy_camera",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
  "bevy_picking",
  "bevy_reflect",
+ "bevy_ui",
  "bevy_window",
  "log",
  "thiserror 2.0.17",
@@ -953,9 +947,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5e645f9e1a24c9667c768b6233beaf4e241739d8ca4fbba59435cc27aabad5"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_a11y",
  "bevy_android",
@@ -972,6 +965,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_gilrs",
  "bevy_gizmos",
+ "bevy_gizmos_render",
  "bevy_gltf",
  "bevy_image",
  "bevy_input",
@@ -1005,9 +999,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_light"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47093733280976ebd595f6e25f76603d5067ca4eb7544e59ecb0dd2fc5147810"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1026,9 +1019,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a2d4ea086ac4663ab9dfb056c7b85eee39e18f7e3e9a4ae6e39897eaa155c5"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -1044,11 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d984f9f8bd0f0d9fb020492a955e641e30e7a425f3588bf346cb3e61fec3c3"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
- "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
@@ -1057,11 +1047,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_math"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa74ae5d968749cc073da991757d3c7e3504ac6dbaac5f8c2a54b9d19b0b7ed"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "approx",
+ "arrayvec",
  "bevy_reflect",
  "derive_more",
  "glam",
@@ -1070,16 +1060,14 @@ dependencies = [
  "rand",
  "rand_distr",
  "serde",
- "smallvec",
  "thiserror 2.0.17",
  "variadics_please",
 ]
 
 [[package]]
 name = "bevy_mesh"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9a0ea86abbd17655bc6f9f8d94461dfcd0322431f752fc03748df8b335eff2"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1108,9 +1096,8 @@ checksum = "7ef8e4b7e61dfe7719bb03c884dc270cd46a82efb40f93e9933b990c5c190c59"
 
 [[package]]
 name = "bevy_pbr"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c514b950cda849aa64e9b076a235913577370275125a34a478758505a19d776"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1144,9 +1131,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_picking"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b371779713b40dea83b24cdb95054fe999fe8372351a317c4fb768859ac5f010"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1168,9 +1154,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4691af6d7cfd1b5deb2fc926a43a180a546cdc3fe1e5a013fcee60db9bb2c81f"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "critical-section",
  "foldhash 0.2.0",
@@ -1189,9 +1174,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_post_process"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b857972f5d56b43b0dce2c843b75b64d5fbbd0f6177f6ecccd75e7e41f72deb"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1219,15 +1203,13 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d24d7906c7de556033168b3485de36c59049fbaef0c2c44c715a23e0329b10"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5472b91928c0f3e4e3988c0d036b00719f19520f53a0c3f8c2af72f00e693c5"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -1253,9 +1235,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083784255162fa39960aa3cf3c23af0e515db2daa7f2e796ae34df993f4d3f6c"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -1267,9 +1248,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44117cbc9448b5a3118eb9c65bd9ec4c574be996148793be2443257daae6eb05"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "async-channel",
  "bevy_app",
@@ -1298,6 +1278,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "encase",
  "fixedbitset",
+ "glam",
  "image",
  "indexmap",
  "js-sys",
@@ -1316,9 +1297,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9557b7b6b06b1b70c147581f4f410c2de73b6f6f0e82915887020f953bacb5a"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -1328,9 +1308,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf6efd31fdd1e05724c95900bb1055716c8e3633b05fa731ee75db4241c17d"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1342,6 +1321,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "derive_more",
+ "ron",
  "serde",
  "thiserror 2.0.17",
  "uuid",
@@ -1349,9 +1329,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_shader"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a655de9f64e113a6e37be76401fb0d6cb84ed7cc4f891e70af4e39d26e9080c3"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_asset",
  "bevy_platform",
@@ -1366,9 +1345,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b9a80aadf102ef0b012ceba5326253638c891994c303479e9973092e4e1c8b"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1391,9 +1369,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite_render"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eec49a2a9185526f9828559a40b6f66d4c2dbae2df8ea2936d88ba449a5e86a"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1423,9 +1400,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_state"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e8556a55d548844fc067fac6657b62f8073c94bd7e13c86aa7573f4c2a67b3"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1439,9 +1415,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_state_macros"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda45913b1d6470c6b751656e72fb3f25ca6b5b7b2ee055b294aaed1eb7e5ba"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -1450,9 +1425,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbbfa5a58a16c4228434d3018c23fde3d78dcd76ec5f5b2b482a21f4b158dd3"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -1469,9 +1443,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc144cc6a30ed44a88e342c22d9e3a66a0993a74f792ae07ba79318efb41a86d"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1495,9 +1468,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32835c3dbe082fbbe7d4f2f37f655073421f2882d4320ac2d59f922474260de4"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1510,9 +1482,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41fabfeaa53f51ff5ccf4d87e66836293159d50d21f6d3e16c93efb7c30f969"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -1528,9 +1499,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0fe27b8c641c2537480774dfd9198d56779371b04dd76618db39da4e7c7483"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "accesskit",
  "bevy_a11y",
@@ -1561,9 +1531,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_ui_render"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d2e783bb5f0b748e6360a0055421d5c934b43830b205a84996a75e54330cd7"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1592,9 +1561,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789d04f88c764877a4552e07745b402dbc45f5d0545e6d102558f2f1752a1d89"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -1603,9 +1571,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae54ec7a0fc344278592a688a01b57b32182abc3ca7d47040773c4cbc2e15e0"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -1622,9 +1589,8 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeaa46d3c4480323e690de8a4ca7f914c074af1f5f70ee3246392992dbf4a0c"
+version = "0.18.0-dev"
+source = "git+https://github.com/bevyengine/bevy?branch=main#41f59f1891067799eac93796b3e1ffb9775002b5"
 dependencies = [
  "accesskit",
  "accesskit_winit",
@@ -2109,6 +2075,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,21 +2105,22 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
+checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
 dependencies = [
  "bitflags 2.10.0",
  "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa",
  "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -2358,30 +2334,29 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encase"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ba239319a4f60905966390f5e52799d868103a533bb7e27822792332504ddd"
+checksum = "6e3e0ff2ee0b7aa97428308dd9e1e42369cb22f5fb8dc1c55546637443a60f1e"
 dependencies = [
  "const_panic",
  "encase_derive",
- "glam",
  "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "encase_derive"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5223d6c647f09870553224f6e37261fe5567bc5a4f4cf13ed337476e79990f2f"
+checksum = "a4d90c5d7d527c6cb8a3b114efd26a6304d9ab772656e73d8f4e32b1f3d601a2"
 dependencies = [
  "encase_derive_impl",
 ]
 
 [[package]]
 name = "encase_derive_impl"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796db3d892515842ca2dfb11124c4bb4a9e58d9f2c5c1072e5bca1b2334507b"
+checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2581,16 +2556,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -2652,6 +2627,36 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -2740,6 +2745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd47b05dddf0005d850e5644cae7f2b14ac3df487979dbfff3b56f20b1a6ae46"
 dependencies = [
  "bytemuck",
+ "encase",
  "libm",
  "rand",
  "serde_core",
@@ -2885,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "0.15.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36119f3a540b086b4e436bb2b588cf98a68863470e0e880f4d0842f112a3183a"
+checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
 
 [[package]]
 name = "guillotiere"
@@ -2909,6 +2915,19 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -2942,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "portable-atomic",
@@ -3261,6 +3280,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4130,7 +4155,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser 0.25.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -4218,6 +4243,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -4562,6 +4593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
+ "core_maths",
  "font-types",
 ]
 
@@ -4642,9 +4674,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beceb6f7bf81c73e73aeef6dd1356d9a1b2b4909e1f0fc3e59b034f9572d7b7f"
+checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
 dependencies = [
  "base64",
  "bitflags 2.10.0",
@@ -4711,23 +4743,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rustybuzz"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
-dependencies = [
- "bitflags 2.10.0",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.21.1",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
 
 [[package]]
 name = "ruzstd"
@@ -5047,9 +5062,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.7.7"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4f4d046dd956a47a7e1a2947083d7ac3e6aa3cfaaead36173ceaa5ab11878c"
+checksum = "41ba83ebaf2954d31d05d67340fd46cebe99da2b7133b0dd68d70c65473a437b"
 dependencies = [
  "arrayvec",
  "grid",
@@ -5319,21 +5334,12 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
-
-[[package]]
-name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "twox-hash"
@@ -5360,18 +5366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,12 +5376,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ type_complexity = "allow"
 too_many_arguments = "allow"
 
 [workspace.dependencies]
-bevy = { version = "0.17", no-default-features = true, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", no-default-features = true, features = [
     "bevy_render",
     "bevy_color",
 ] }


### PR DESCRIPTION
Because we're doing some things that are slightly unusual, we may need to make some small changes upstream to support our patterns. For example, I just had to open https://github.com/bevyengine/bevy/pull/22024.

Because we are committing our lockfile, depending on an unstable branch should be fine, we just need to make sure that everything builds when running `cargo update` to bring in a new Bevy version.

The downside here would be if we depend on third party Bevy ecosystem crates, for example `bevy_vello`. However, we're not there yet and in many cases it's possible just to patch the dependency assuming there aren't major breaking changes: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section. Ecosystem crates also always appreciate a PR to bring them up to date. (:

But let's cross that bridge when we get there!