### PR TITLE
Add camera functions

### DIFF
--- a/crates/processing_ffi/src/lib.rs
+++ b/crates/processing_ffi/src/lib.rs
@@ -524,3 +524,64 @@ pub unsafe extern "C" fn processing_image_readback(
         Ok(())
     });
 }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_mode_3d(window_id: u64) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_mode_3d(window_entity));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_mode_2d(window_id: u64) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_mode_2d(window_entity));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_camera_position(window_id: u64, x: f32, y: f32, z: f32) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_camera_position(window_entity, x, y, z));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_camera_look_at(
+    window_id: u64,
+    target_x: f32,
+    target_y: f32,
+    target_z: f32,
+) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_camera_look_at(window_entity, target_x, target_y, target_z));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_perspective(
+    window_id: u64,
+    fov: f32,
+    aspect: f32,
+    near: f32,
+    far: f32,
+) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_perspective(window_entity, fov, aspect, near, far));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn processing_ortho(
+    window_id: u64,
+    left: f32,
+    right: f32,
+    bottom: f32,
+    top: f32,
+    near: f32,
+    far: f32,
+) {
+    error::clear_error();
+    let window_entity = Entity::from_bits(window_id);
+    error::check(|| graphics_ortho(window_entity, left, right, bottom, top, near, far));
+}

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -169,6 +169,43 @@ impl Graphics {
     pub fn end_draw(&self) -> PyResult<()> {
         graphics_end_draw(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
+
+    pub fn mode_3d(&self) -> PyResult<()> {
+        graphics_mode_3d(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    pub fn mode_2d(&self) -> PyResult<()> {
+        graphics_mode_2d(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    pub fn camera_position(&self, x: f32, y: f32, z: f32) -> PyResult<()> {
+        graphics_camera_position(self.entity, x, y, z)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    pub fn camera_look_at(&self, target_x: f32, target_y: f32, target_z: f32) -> PyResult<()> {
+        graphics_camera_look_at(self.entity, target_x, target_y, target_z)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    pub fn perspective(&self, fov: f32, aspect: f32, near: f32, far: f32) -> PyResult<()> {
+        graphics_perspective(self.entity, fov, aspect, near, far)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn ortho(
+        &self,
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> PyResult<()> {
+        graphics_ortho(self.entity, left, right, bottom, top, near, far)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
 }
 
 // TODO: a real color type. or color parser? idk. color is confusing. let's think

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -17,6 +17,7 @@ use bevy::{
 use render::{activate_cameras, clear_transient_meshes, flush_draw_commands};
 use tracing::debug;
 
+use crate::graphics::flush;
 use crate::{
     graphics::GraphicsPlugin, image::ImagePlugin, render::command::DrawCommand,
     surface::SurfacePlugin,
@@ -441,6 +442,112 @@ pub fn graphics_record_command(graphics_entity: Entity, cmd: DrawCommand) -> err
     app_mut(|app| {
         app.world_mut()
             .run_system_cached_with(graphics::record_command, (graphics_entity, cmd))
+            .unwrap()
+    })
+}
+
+pub fn graphics_mode_3d(graphics_entity: Entity) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(graphics::mode_3d, graphics_entity)
+            .unwrap()
+    })
+}
+
+pub fn graphics_mode_2d(graphics_entity: Entity) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(graphics::mode_2d, graphics_entity)
+            .unwrap()
+    })
+}
+
+pub fn graphics_camera_position(
+    graphics_entity: Entity,
+    x: f32,
+    y: f32,
+    z: f32,
+) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(graphics::camera_position, (graphics_entity, x, y, z))
+            .unwrap()
+    })
+}
+
+pub fn graphics_camera_look_at(
+    graphics_entity: Entity,
+    target_x: f32,
+    target_y: f32,
+    target_z: f32,
+) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(
+                graphics::camera_look_at,
+                (graphics_entity, target_x, target_y, target_z),
+            )
+            .unwrap()
+    })
+}
+
+pub fn graphics_perspective(
+    graphics_entity: Entity,
+    fov: f32,
+    aspect_ratio: f32,
+    near: f32,
+    far: f32,
+) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(
+                graphics::perspective,
+                (
+                    graphics_entity,
+                    PerspectiveProjection {
+                        fov,
+                        aspect_ratio,
+                        near,
+                        far,
+                    },
+                ),
+            )
+            .unwrap()
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn graphics_ortho(
+    graphics_entity: Entity,
+    left: f32,
+    right: f32,
+    bottom: f32,
+    top: f32,
+    near: f32,
+    far: f32,
+) -> error::Result<()> {
+    app_mut(|app| {
+        flush(app, graphics_entity)?;
+        app.world_mut()
+            .run_system_cached_with(
+                graphics::ortho,
+                (
+                    graphics_entity,
+                    graphics::OrthoArgs {
+                        left,
+                        right,
+                        bottom,
+                        top,
+                        near,
+                        far,
+                    },
+                ),
+            )
             .unwrap()
     })
 }


### PR DESCRIPTION
Prereq to doing anything useful with geometry.

I went back and forth about whether this should be a separate API object. But it's not in Bevy and so I think it's fine to express in terms of graphics here too. This is what Bevy calls "camera driven rendering", where the main graphics context is also a camera. There are pros and cons here but this is close to processing4 and so good enough for now, I think.