### PR TITLE
[processing_pyo3] Image class

### DIFF
--- a/crates/processing_pyo3/examples/background_image.py
+++ b/crates/processing_pyo3/examples/background_image.py
@@ -1,7 +1,5 @@
 from processing import *
 
-i = None 
-
 def setup():
     global i
     size(800, 600)
@@ -9,9 +7,7 @@ def setup():
 
 
 def draw():
-    global i
     background(220, 100, 24)
-    # i = image("images/logo.png")
     background(i)
 
 

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -24,17 +24,16 @@ impl Drop for Surface {
 }
 
 #[pyclass]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Image {
     entity: Entity,
 }
 
-// TODO: we lose the image if this is implemented, meaning that the image is getting dropped prematurely
-// impl Drop for Image {
-//     fn drop(&mut self) {
-//         let _ = image_destroy(self.entity);
-//     }
-// }
+impl Drop for Image {
+    fn drop(&mut self) {
+        let _ = image_destroy(self.entity);
+    }
+}
 
 #[pyclass(unsendable)]
 pub struct Graphics {
@@ -84,7 +83,7 @@ impl Graphics {
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
-    pub fn background_image(&self, image: Image) -> PyResult<()> {
+    pub fn background_image(&self, image: &Image) -> PyResult<()> {
         graphics_record_command(self.entity, DrawCommand::BackgroundImage(image.entity))
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -102,7 +102,7 @@ fn run(module: &Bound<'_, PyModule>) -> PyResult<()> {
 fn background(module: &Bound<'_, PyModule>, args: &Bound<'_, PyTuple>) -> PyResult<()> {
     let first = args.get_item(0)?;
     if first.is_instance_of::<Image>() {
-        get_graphics(module)?.background_image(first.extract::<Image>()?)
+        get_graphics(module)?.background_image(&*first.extract::<PyRef<Image>>()?)
     } else {
         get_graphics(module)?.background(args.extract()?)
     }


### PR DESCRIPTION
Addresses #51 

There is now an Image pyclass and we pass it in. You can call `background()` on either an Image or pass arguments for color. 

One thing to note however is there is something I need to figure out with `impl Drop for Image {}` because if implemented the image gets dropped prematurely. This tells me there is a life time error of some sort.

I'm putting up the PR, however, I don't think it should be merged in until we know what is going on with it being dropped. 