### PR TITLE
Generic CommandBuffer<T>, and processing_utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4432,6 +4432,7 @@ dependencies = [
  "lyon",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
+ "processing_utils",
  "raw-window-handle",
  "thiserror 2.0.17",
  "tracing",
@@ -4440,6 +4441,13 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "processing_utils"
+version = "0.1.0"
+dependencies = [
+ "bevy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 processing = { path = "." }
 processing_pyo3 = { path = "crates/processing_pyo3" }
 processing_render = { path = "crates/processing_render" }
+processing_utils = { path = "crates/processing_utils" }
 
 [dependencies]
 bevy = { workspace = true }

--- a/crates/processing_render/Cargo.toml
+++ b/crates/processing_render/Cargo.toml
@@ -13,6 +13,7 @@ x11 = ["bevy/x11"]
 
 [dependencies]
 bevy = { workspace = true }
+processing_utils = { workspace = true }
 lyon = "1.0"
 raw-window-handle = "0.6"
 thiserror = "2"

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -29,12 +29,11 @@ use crate::{
     Flush,
     error::{ProcessingError, Result},
     image::{Image, bytes_to_pixels, create_readback_buffer, pixel_size, pixels_to_bytes},
-    render::{
-        RenderState,
-        command::{CommandBuffer, DrawCommand},
-    },
+    render::{RenderState, command::DrawCommand},
     surface::Surface,
 };
+
+use processing_utils::CommandBuffer;
 
 pub struct GraphicsPlugin;
 
@@ -242,7 +241,7 @@ pub fn create(
             }),
             Transform::from_xyz(0.0, 0.0, 999.9),
             render_layer,
-            CommandBuffer::new(),
+            CommandBuffer::<DrawCommand>::new(),
             RenderState::default(),
             SurfaceSize(width, height),
             Graphics {
@@ -465,7 +464,7 @@ pub fn end_draw(app: &mut App, entity: Entity) -> Result<()> {
 
 pub fn record_command(
     In((graphics_entity, cmd)): In<(Entity, DrawCommand)>,
-    mut graphics_query: Query<&mut CommandBuffer>,
+    mut graphics_query: Query<&mut CommandBuffer<DrawCommand>>,
 ) -> Result<()> {
     let mut command_buffer = graphics_query
         .get_mut(graphics_entity)

--- a/crates/processing_render/src/render/command.rs
+++ b/crates/processing_render/src/render/command.rs
@@ -38,24 +38,3 @@ pub enum DrawCommand {
     },
     Geometry(Entity),
 }
-
-#[derive(Debug, Default, Component)]
-pub struct CommandBuffer {
-    pub commands: Vec<DrawCommand>,
-}
-
-impl CommandBuffer {
-    pub fn new() -> Self {
-        Self {
-            commands: Vec::new(),
-        }
-    }
-
-    pub fn push(&mut self, cmd: DrawCommand) {
-        self.commands.push(cmd);
-    }
-
-    pub fn clear(&mut self) {
-        self.commands.clear();
-    }
-}

--- a/crates/processing_render/src/render/mod.rs
+++ b/crates/processing_render/src/render/mod.rs
@@ -10,13 +10,15 @@ use bevy::{
     math::{Affine3A, Mat4, Vec4},
     prelude::*,
 };
-use command::{CommandBuffer, DrawCommand};
+use command::DrawCommand;
 use material::MaterialKey;
 use primitive::{TessellationMode, empty_mesh};
 use transform::TransformStack;
 
 use crate::render::material::UntypedMaterial;
 use crate::{Flush, geometry::Geometry, image::Image, render::primitive::rect};
+
+use processing_utils::CommandBuffer;
 
 #[derive(Component)]
 #[relationship(relationship_target = TransientMeshes)]
@@ -93,7 +95,7 @@ pub fn flush_draw_commands(
     mut graphics: Query<
         (
             Entity,
-            &mut CommandBuffer,
+            &mut CommandBuffer<DrawCommand>,
             &mut RenderState,
             &RenderLayers,
             &Projection,

--- a/crates/processing_utils/Cargo.toml
+++ b/crates/processing_utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "processing_utils"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bevy = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/processing_utils/src/lib.rs
+++ b/crates/processing_utils/src/lib.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+
+#[derive(Debug, Default, Component)]
+pub struct CommandBuffer<T> {
+    pub commands: Vec<T>,
+}
+
+impl<T> CommandBuffer<T> {
+    pub fn new() -> Self {
+        Self {
+            commands: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, cmd: T) {
+        self.commands.push(cmd);
+    }
+
+    pub fn clear(&mut self) {
+        self.commands.clear();
+    }
+}


### PR DESCRIPTION
I'm working on some midi stuff, and realizing that it will need its own CommandBuffer, and `MidiCommand` enum to interact with the bevy ECS. 

So I've made this generic CommandBuffer<T> and put it in a shared utils crate `processing_utils`. 

If I understand it correctly, many systems we bring in will need this type of CommandBuffer? But if I'm wrong and this is a bad idea, I can let it go :) 

