### PR TITLE
move file_watcher to pyo3 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ type_complexity = "allow"
 too_many_arguments = "allow"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", features = ["file_watcher"] }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main" }
 processing = { path = "." }
 processing_pyo3 = { path = "crates/processing_pyo3" }
 processing_render = { path = "crates/processing_render" }

--- a/crates/processing_pyo3/Cargo.toml
+++ b/crates/processing_pyo3/Cargo.toml
@@ -18,7 +18,7 @@ x11 = ["processing/x11"]
 [dependencies]
 pyo3 = "0.27.0"
 processing = { workspace = true }
-bevy = { workspace = true }
+bevy = { workspace = true, features = ["file_watcher"] }
 glfw = { version = "0.60.0"}
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
the way I had the `file_watcher` feature added ended up breaking the wasm builds. So i've moved out that feature from the processing cargo, and asked for it in `processing_pyo3`