### PR TITLE
Add Geometry uv and vertex_count methods

### DIFF
--- a/crates/processing_pyo3/examples/geometry_methods.py
+++ b/crates/processing_pyo3/examples/geometry_methods.py
@@ -1,0 +1,38 @@
+from mewnala import *
+
+geometry = None
+
+
+def setup():
+    global geometry
+    size(640, 480)
+    mode_3d()
+
+    geometry = Geometry()
+
+    geometry.normal(0.0, 0.0, 1.0)
+
+    geometry.uv(0.0, 0.0)
+    geometry.vertex(-80.0, -80.0, 0.0)
+
+    geometry.uv(1.0, 0.0)
+    geometry.vertex(80.0, -80.0, 0.0)
+
+    geometry.uv(0.5, 1.0)
+    geometry.vertex(0.0, 80.0, 0.0)
+
+    geometry.index(0)
+    geometry.index(1)
+    geometry.index(2)
+
+    print("vertex_count =", geometry.vertex_count())
+
+
+def draw():
+    background(220)
+    camera_position(0.0, 0.0, 200.0)
+    camera_look_at(0.0, 0.0, 0.0)
+    draw_geometry(geometry)
+
+
+run()

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -1,9 +1,6 @@
 use crate::color::{ColorMode, extract_color_with_mode};
-use crate::color::{ColorMode, extract_color_with_mode};
-use crate::glfw::GlfwContext;
 use crate::glfw::GlfwContext;
 use crate::input;
-use crate::math::{extract_vec2, extract_vec3, extract_vec4};
 use crate::math::{extract_vec2, extract_vec3, extract_vec4};
 use bevy::{
     color::{ColorToPacked, Srgba},
@@ -152,6 +149,12 @@ impl Geometry {
         geometry_vertex(self.entity, v).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
+    #[pyo3(signature = (*args))]
+    pub fn uv(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+        let v = extract_vec2(args)?;
+        geometry_uv(self.entity, v.x, v.y).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
     pub fn index(&self, i: u32) -> PyResult<()> {
         geometry_index(self.entity, i).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
@@ -160,6 +163,10 @@ impl Geometry {
     pub fn set_vertex(&self, i: u32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
         let v = extract_vec3(args)?;
         geometry_set_vertex(self.entity, i, v).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    pub fn vertex_count(&self) -> PyResult<u32> {
+        geometry_vertex_count(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 }
 


### PR DESCRIPTION
Add `uv()` and `vertex_count()` to `Geometry` in `processing_pyo3`.

Part of #52.

What’s included:

* `Geometry.uv(...)`
* `Geometry.vertex_count()`
* a small example in `crates/processing_pyo3/examples/geometry_methods.py`
