### PR TITLE
Add globals and callback handling

### DIFF
--- a/crates/processing_input/src/lib.rs
+++ b/crates/processing_input/src/lib.rs
@@ -295,3 +295,47 @@ pub fn input_key() -> error::Result<Option<char>> {
 pub fn input_key_code() -> error::Result<Option<KeyCode>> {
     app_mut(|app| Ok(app.world().resource::<LastKey>().code))
 }
+
+pub fn input_mouse_any_just_pressed() -> error::Result<bool> {
+    app_mut(|app| {
+        Ok(app
+            .world()
+            .resource::<ButtonInput<MouseButton>>()
+            .get_just_pressed()
+            .next()
+            .is_some())
+    })
+}
+
+pub fn input_mouse_any_just_released() -> error::Result<bool> {
+    app_mut(|app| {
+        Ok(app
+            .world()
+            .resource::<ButtonInput<MouseButton>>()
+            .get_just_released()
+            .next()
+            .is_some())
+    })
+}
+
+pub fn input_key_any_just_pressed() -> error::Result<bool> {
+    app_mut(|app| Ok(app.world().resource::<LastKey>().just_pressed))
+}
+
+pub fn input_key_any_just_released() -> error::Result<bool> {
+    app_mut(|app| Ok(app.world().resource::<LastKey>().just_released))
+}
+
+pub fn input_mouse_moved() -> error::Result<bool> {
+    app_mut(|app| {
+        let d = app.world().resource::<AccumulatedMouseMotion>().delta;
+        Ok(d.x != 0.0 || d.y != 0.0)
+    })
+}
+
+pub fn input_mouse_scrolled() -> error::Result<bool> {
+    app_mut(|app| {
+        let d = app.world().resource::<AccumulatedMouseScroll>().delta;
+        Ok(d.x != 0.0 || d.y != 0.0)
+    })
+}

--- a/crates/processing_input/src/state.rs
+++ b/crates/processing_input/src/state.rs
@@ -26,6 +26,8 @@ impl CursorPosition {
 pub struct LastKey {
     pub code: Option<KeyCode>,
     pub character: Option<char>,
+    pub just_pressed: bool,
+    pub just_released: bool,
 }
 
 #[derive(Resource, Default)]
@@ -51,13 +53,21 @@ pub fn track_cursor_position(
 }
 
 pub fn track_last_key(mut reader: MessageReader<KeyboardInput>, mut last: ResMut<LastKey>) {
-    if let Some(event) = reader
-        .read()
-        .filter(|e| e.state == ButtonState::Pressed)
-        .last()
-    {
-        last.code = Some(event.key_code);
-        last.character = event.text.as_ref().and_then(|t| t.chars().next());
+    // our cbs fire on key auto repeats but bevy just_pressed only fires on the initial press
+    // we track edge state off of the raw input stream
+    last.just_pressed = false;
+    last.just_released = false;
+    for event in reader.read() {
+        match event.state {
+            ButtonState::Pressed => {
+                last.code = Some(event.key_code);
+                last.character = event.text.as_ref().and_then(|t| t.chars().next());
+                last.just_pressed = true;
+            }
+            ButtonState::Released => {
+                last.just_released = true;
+            }
+        }
     }
 }
 

--- a/crates/processing_pyo3/mewnala/__init__.py
+++ b/crates/processing_pyo3/mewnala/__init__.py
@@ -9,4 +9,66 @@ for _name in ("math", "color"):
     _sub = getattr(_native, _name, None)
     if _sub is not None:
         _sys.modules[f"{__name__}.{_name}"] = _sub
-del _sys, _native, _name, _sub
+
+# global var handling. for wildcard import of our module, we copy into globals, otherwise
+# we dispatch to get attr and call the underlying getter method 
+
+_DYNAMIC_GRAPHICS_ATTRS = (
+    "width",
+    "height",
+    "focused",
+    "pixel_width",
+    "pixel_height",
+    "pixel_density",
+)
+_DYNAMIC_FUNCTIONS = (
+    "mouse_x",
+    "mouse_y",
+    "pmouse_x",
+    "pmouse_y",
+    "frame_count",
+    "delta_time",
+    "elapsed_time",
+)
+_DYNAMIC = (
+    _DYNAMIC_GRAPHICS_ATTRS + _DYNAMIC_FUNCTIONS + (
+        "mouse_is_pressed",
+        "mouse_button",
+        "moved_x",
+        "moved_y",
+        "mouse_wheel",
+        "key",
+        "key_code",
+        "key_is_pressed",
+        "display_width",
+        "display_height",
+    )
+)
+
+
+def _get_graphics():
+    return getattr(_native, "_graphics", None)
+
+
+def __getattr__(name):
+    if name in _DYNAMIC_GRAPHICS_ATTRS:
+        g = _get_graphics()
+        if g is not None:
+            return getattr(g, name)
+    if name in _DYNAMIC_FUNCTIONS:
+        fn = getattr(_native, name, None)
+        if callable(fn):
+            return fn()
+    if name in ("display_width", "display_height"):
+        mon = getattr(_native, "primary_monitor", lambda: None)()
+        if mon is None:
+            return 0
+        return mon.width if name == "display_width" else mon.height
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys()) + list(_DYNAMIC)))
+
+
+del _sys, _name, _sub

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -132,40 +132,7 @@ impl PyBlendMode {
     const OP_MAX: u8 = 4;
 }
 
-#[pyclass(unsendable)]
-pub struct Surface {
-    pub(crate) entity: Entity,
-    glfw_ctx: Option<GlfwContext>,
-}
-
-#[pymethods]
-impl Surface {
-    pub fn poll_events(&mut self) -> bool {
-        match &mut self.glfw_ctx {
-            Some(ctx) => ctx.poll_events(),
-            None => true, // no-op, offscreen surfaces never close
-        }
-    }
-
-    #[getter]
-    pub fn display_density(&self) -> PyResult<f32> {
-        match &self.glfw_ctx {
-            Some(ctx) => Ok(ctx.content_scale()),
-            None => Ok(1.0),
-        }
-    }
-
-    pub fn set_pixel_density(&self, density: f32) -> PyResult<()> {
-        surface_set_pixel_density(self.entity, density)
-            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
-    }
-}
-
-impl Drop for Surface {
-    fn drop(&mut self) {
-        let _ = surface_destroy(self.entity);
-    }
-}
+pub use crate::surface::Surface;
 
 #[pyclass]
 #[derive(Debug)]
@@ -318,6 +285,10 @@ impl Geometry {
 pub struct Graphics {
     pub(crate) entity: Entity,
     pub surface: Surface,
+    #[pyo3(get)]
+    pub width: u32,
+    #[pyo3(get)]
+    pub height: u32,
 }
 
 impl Drop for Graphics {
@@ -364,6 +335,8 @@ impl Graphics {
         Ok(Self {
             entity: graphics,
             surface,
+            width,
+            height,
         })
     }
 
@@ -399,7 +372,29 @@ impl Graphics {
         Ok(Self {
             entity: graphics,
             surface,
+            width,
+            height,
         })
+    }
+
+    #[getter]
+    pub fn focused(&self) -> PyResult<bool> {
+        self.surface.focused()
+    }
+
+    #[getter]
+    pub fn pixel_density(&self) -> PyResult<f32> {
+        self.surface.pixel_density()
+    }
+
+    #[getter]
+    pub fn pixel_width(&self) -> PyResult<u32> {
+        self.surface.pixel_width()
+    }
+
+    #[getter]
+    pub fn pixel_height(&self) -> PyResult<u32> {
+        self.surface.pixel_height()
     }
 
     pub fn readback_png(&self) -> PyResult<Vec<u8>> {

--- a/crates/processing_pyo3/src/input.rs
+++ b/crates/processing_pyo3/src/input.rs
@@ -80,20 +80,20 @@ pub fn key_code() -> PyResult<Option<u32>> {
         .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
 }
 
-pub fn sync_globals(func: &Bound<'_, PyAny>, surface: Entity) -> PyResult<()> {
-    let globals = func.getattr("__globals__")?;
-    globals.set_item("mouse_x", mouse_x(surface)?)?;
-    globals.set_item("mouse_y", mouse_y(surface)?)?;
-    globals.set_item("pmouse_x", pmouse_x(surface)?)?;
-    globals.set_item("pmouse_y", pmouse_y(surface)?)?;
-    globals.set_item("mouse_is_pressed", mouse_is_pressed()?)?;
-    globals.set_item("mouse_button", mouse_button()?)?;
-    globals.set_item("moved_x", moved_x()?)?;
-    globals.set_item("moved_y", moved_y()?)?;
-    globals.set_item("mouse_wheel", mouse_wheel()?)?;
-    globals.set_item("key", key()?)?;
-    globals.set_item("key_code", key_code()?)?;
-    globals.set_item("key_is_pressed", key_is_pressed()?)?;
+pub fn sync_globals(globals: &Bound<'_, PyAny>, surface: Entity) -> PyResult<()> {
+    use crate::set_tracked;
+    set_tracked(globals, "mouse_x", mouse_x(surface)?)?;
+    set_tracked(globals, "mouse_y", mouse_y(surface)?)?;
+    set_tracked(globals, "pmouse_x", pmouse_x(surface)?)?;
+    set_tracked(globals, "pmouse_y", pmouse_y(surface)?)?;
+    set_tracked(globals, "mouse_is_pressed", mouse_is_pressed()?)?;
+    set_tracked(globals, "mouse_button", mouse_button()?)?;
+    set_tracked(globals, "moved_x", moved_x()?)?;
+    set_tracked(globals, "moved_y", moved_y()?)?;
+    set_tracked(globals, "mouse_wheel", mouse_wheel()?)?;
+    set_tracked(globals, "key", key()?)?;
+    set_tracked(globals, "key_code", key_code()?)?;
+    set_tracked(globals, "key_is_pressed", key_is_pressed()?)?;
     Ok(())
 }
 

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -18,7 +18,10 @@ mod input;
 pub(crate) mod material;
 pub(crate) mod math;
 mod midi;
+mod monitor;
 pub(crate) mod shader;
+mod surface;
+mod time;
 #[cfg(feature = "webcam")]
 mod webcam;
 
@@ -28,6 +31,7 @@ use graphics::{
 use material::Material;
 
 use pyo3::{
+    BoundObject,
     exceptions::PyRuntimeError,
     prelude::*,
     types::{PyDict, PyTuple},
@@ -37,7 +41,103 @@ use std::ffi::{CStr, CString};
 
 use bevy::log::warn;
 use gltf::Gltf;
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::env;
+
+thread_local! {
+    static LAST_GLOBALS: RefCell<HashMap<&'static str, Py<PyAny>>> = RefCell::new(HashMap::new());
+}
+
+
+/// Writes a new value to globals, iff the new value does not match a previous tracked value.
+pub(crate) fn set_tracked<'py, V>(
+    globals: &Bound<'py, PyAny>,
+    name: &'static str,
+    new_value: V,
+) -> PyResult<()>
+where
+    V: IntoPyObject<'py>,
+    PyErr: From<V::Error>,
+{
+    let py = globals.py();
+    let owned: Py<PyAny> = new_value.into_pyobject(py)?.into_any().unbind();
+
+    let user_shadowed = LAST_GLOBALS.with(|cache| -> PyResult<bool> {
+        let cache = cache.borrow();
+        let Some(last) = cache.get(name) else {
+            return Ok(false);
+        };
+        match globals.get_item(name) {
+            Ok(current) => Ok(!current.eq(last.bind(py))?),
+            // key isn't in globals, either because the dict is fresh (livecode reload etc)
+            // or the user deleted it so we can safely repopulate
+            Err(_) => Ok(false),
+        }
+    })?;
+
+    if !user_shadowed {
+        globals.set_item(name, owned.clone_ref(py))?;
+        LAST_GLOBALS.with(|cache| {
+            cache.borrow_mut().insert(name, owned);
+        });
+    }
+
+    Ok(())
+}
+
+pub(crate) fn reset_tracked_globals() {
+    LAST_GLOBALS.with(|cache| cache.borrow_mut().clear());
+}
+
+fn sync_globals(module: &Bound<'_, PyModule>, globals: &Bound<'_, PyAny>) -> PyResult<()> {
+    let graphics =
+        get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
+    input::sync_globals(globals, graphics.surface.entity)?;
+    surface::sync_globals(globals, &graphics.surface, graphics.width, graphics.height)?;
+    time::sync_globals(globals)?;
+    Ok(())
+}
+
+fn try_call(locals: &Bound<'_, PyAny>, name: &str) -> PyResult<()> {
+    if let Ok(cb) = locals.get_item(name)
+        && cb.is_callable()
+    {
+        cb.call0()
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    }
+    Ok(())
+}
+
+fn dispatch_event_callbacks(locals: &Bound<'_, PyAny>) -> PyResult<()> {
+    use processing::prelude::*;
+    let err =
+        |e: processing::prelude::error::ProcessingError| PyRuntimeError::new_err(format!("{e}"));
+
+    if input_mouse_any_just_pressed().map_err(err)? {
+        try_call(locals, "mouse_pressed")?;
+    }
+    if input_mouse_any_just_released().map_err(err)? {
+        try_call(locals, "mouse_released")?;
+    }
+    if input_mouse_moved().map_err(err)? {
+        if input_mouse_is_pressed().map_err(err)? {
+            try_call(locals, "mouse_dragged")?;
+        } else {
+            try_call(locals, "mouse_moved")?;
+        }
+    }
+    if input_mouse_scrolled().map_err(err)? {
+        try_call(locals, "mouse_wheel")?;
+    }
+    if input_key_any_just_pressed().map_err(err)? {
+        try_call(locals, "key_pressed")?;
+    }
+    if input_key_any_just_released().map_err(err)? {
+        try_call(locals, "key_released")?;
+    }
+    Ok(())
+}
 
 /// Get a shared ref to the Graphics context, or return Ok(()) if not yet initialized.
 macro_rules! graphics {
@@ -139,6 +239,10 @@ mod mewnala {
     #[cfg(feature = "cuda")]
     #[pymodule_export]
     use super::cuda::CudaImage;
+    #[pymodule_export]
+    use super::monitor::Monitor;
+    #[pymodule_export]
+    use super::surface::Surface;
 
     // Stroke cap/join
     #[pymodule_export]
@@ -597,6 +701,17 @@ mod mewnala {
 
     #[pyfunction]
     #[pyo3(pass_module)]
+    fn _tick(module: &Bound<'_, PyModule>, ns: &Bound<'_, PyAny>) -> PyResult<()> {
+        if get_graphics(module)?.is_none() {
+            return Ok(());
+        }
+        sync_globals(module, ns)?;
+        dispatch_event_callbacks(ns)?;
+        Ok(())
+    }
+
+    #[pyfunction]
+    #[pyo3(pass_module)]
     fn redraw(module: &Bound<'_, PyModule>) -> PyResult<()> {
         graphics!(module).present()
     }
@@ -703,12 +818,10 @@ mod mewnala {
             // call setup
             setup_fn.call0()?;
 
-            let mut frame_count: u64 = 0;
-            {
-                let graphics = get_graphics(module)?
-                    .ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-                input::sync_globals(&draw_fn, graphics.surface.entity)?;
-            }
+            let mut globals = draw_fn.getattr("__globals__")?;
+            sync_globals(module, &globals)?;
+
+            // start draw loop
             loop {
                 {
                     let mut graphics = get_graphics_mut(module)?
@@ -730,6 +843,10 @@ mod mewnala {
                         }
 
                         draw_fn = locals.get_item("draw").unwrap().unwrap();
+                        globals = draw_fn.getattr("__globals__")?;
+                        reset_tracked_globals();
+
+                        dbg!(locals);
                     }
 
                     if !graphics.surface.poll_events() {
@@ -738,14 +855,8 @@ mod mewnala {
                     graphics.begin_draw()?;
                 }
 
-                {
-                    let graphics = get_graphics(module)?
-                        .ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-                    input::sync_globals(&draw_fn, graphics.surface.entity)?;
-                    let globals = draw_fn.getattr("__globals__")?;
-                    globals.set_item("frame_count", frame_count)?;
-                    frame_count += 1;
-                }
+                sync_globals(module, &globals)?;
+                dispatch_event_callbacks(&locals)?;
 
                 draw_fn
                     .call0()
@@ -1445,5 +1556,30 @@ mod mewnala {
         let graphics =
             get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
         graphics.surface.display_density()
+    }
+
+    #[pyfunction]
+    fn frame_count() -> PyResult<u32> {
+        time::frame_count()
+    }
+
+    #[pyfunction]
+    fn delta_time() -> PyResult<f32> {
+        time::delta_time()
+    }
+
+    #[pyfunction]
+    fn elapsed_time() -> PyResult<f32> {
+        time::elapsed_time()
+    }
+
+    #[pyfunction]
+    fn monitors() -> PyResult<Vec<monitor::Monitor>> {
+        monitor::list()
+    }
+
+    #[pyfunction]
+    fn primary_monitor() -> PyResult<Option<monitor::Monitor>> {
+        monitor::primary()
     }
 }

--- a/crates/processing_pyo3/src/monitor.rs
+++ b/crates/processing_pyo3/src/monitor.rs
@@ -1,0 +1,50 @@
+use bevy::prelude::Entity;
+use processing::prelude::*;
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
+
+#[pyclass(unsendable)]
+pub struct Monitor {
+    pub(crate) entity: Entity,
+}
+
+#[pymethods]
+impl Monitor {
+    #[getter]
+    pub fn width(&self) -> PyResult<u32> {
+        monitor_width(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn height(&self) -> PyResult<u32> {
+        monitor_height(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn scale_factor(&self) -> PyResult<f64> {
+        monitor_scale_factor(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn refresh_rate_millihertz(&self) -> PyResult<Option<u32>> {
+        monitor_refresh_rate_millihertz(self.entity)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn name(&self) -> PyResult<Option<String>> {
+        monitor_name(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+}
+
+pub fn primary() -> PyResult<Option<Monitor>> {
+    let entity = monitor_primary().map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    Ok(entity.map(|entity| Monitor { entity }))
+}
+
+pub fn list() -> PyResult<Vec<Monitor>> {
+    let entities = monitor_list().map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    Ok(entities
+        .into_iter()
+        .map(|entity| Monitor { entity })
+        .collect())
+}

--- a/crates/processing_pyo3/src/python/ipython_post_execute.py
+++ b/crates/processing_pyo3/src/python/ipython_post_execute.py
@@ -1,8 +1,10 @@
-import processing
+import mewnala
 
 def _processing_post_execute(result):
-    processing._present()
-    if not processing._poll_events():
-        processing._graphics = None
+    mewnala._present()
+    if not mewnala._poll_events():
+        mewnala._graphics = None
+        return
+    mewnala._tick(get_ipython().user_ns)
 
 get_ipython().events.register('post_run_cell', _processing_post_execute)

--- a/crates/processing_pyo3/src/python/jupyter_post_execute.py
+++ b/crates/processing_pyo3/src/python/jupyter_post_execute.py
@@ -1,9 +1,10 @@
-import processing
+import mewnala
 import IPython.display as _ipy_display
 
 def _processing_post_execute(result):
-    processing._present()
-    png_data = processing._readback_png()
+    mewnala._present()
+    mewnala._tick(get_ipython().user_ns)
+    png_data = mewnala._readback_png()
     if png_data is not None:
         _ipy_display.display(_ipy_display.Image(data=bytes(png_data)))
 

--- a/crates/processing_pyo3/src/python/register_inputhook.py
+++ b/crates/processing_pyo3/src/python/register_inputhook.py
@@ -1,12 +1,17 @@
-import processing
+import mewnala
 import time
+import traceback
 from IPython.terminal.pt_inputhooks import register
 
 def _processing_inputhook(context):
     while not context.input_is_ready():
-        if not processing._poll_events():
-            processing._graphics = None
+        if not mewnala._poll_events():
+            mewnala._graphics = None
             break
+        try:
+            mewnala._tick(get_ipython().user_ns)
+        except Exception:
+            traceback.print_exc()
         time.sleep(1.0 / 60.0)
 
 register('processing', _processing_inputhook)

--- a/crates/processing_pyo3/src/surface.rs
+++ b/crates/processing_pyo3/src/surface.rs
@@ -1,0 +1,84 @@
+use bevy::prelude::Entity;
+use processing::prelude::*;
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
+
+use crate::glfw::GlfwContext;
+use crate::monitor;
+use crate::set_tracked;
+
+#[pyclass(unsendable)]
+pub struct Surface {
+    pub(crate) entity: Entity,
+    pub(crate) glfw_ctx: Option<GlfwContext>,
+}
+
+#[pymethods]
+impl Surface {
+    pub fn poll_events(&mut self) -> bool {
+        match &mut self.glfw_ctx {
+            Some(ctx) => ctx.poll_events(),
+            None => true, // no-op, offscreen surfaces never close
+        }
+    }
+
+    #[getter]
+    pub fn focused(&self) -> PyResult<bool> {
+        surface_focused(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn pixel_density(&self) -> PyResult<f32> {
+        surface_scale_factor(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn pixel_width(&self) -> PyResult<u32> {
+        surface_physical_width(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn pixel_height(&self) -> PyResult<u32> {
+        surface_physical_height(self.entity).map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[getter]
+    pub fn display_density(&self) -> PyResult<f32> {
+        match &self.glfw_ctx {
+            Some(ctx) => Ok(ctx.content_scale()),
+            None => Ok(1.0),
+        }
+    }
+
+    pub fn set_pixel_density(&self, density: f32) -> PyResult<()> {
+        surface_set_pixel_density(self.entity, density)
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+}
+
+impl Drop for Surface {
+    fn drop(&mut self) {
+        let _ = surface_destroy(self.entity);
+    }
+}
+
+pub fn sync_globals(
+    globals: &Bound<'_, PyAny>,
+    surface: &Surface,
+    canvas_width: u32,
+    canvas_height: u32,
+) -> PyResult<()> {
+    set_tracked(globals, "width", canvas_width)?;
+    set_tracked(globals, "height", canvas_height)?;
+    set_tracked(globals, "focused", surface.focused()?)?;
+    set_tracked(globals, "pixel_density", surface.pixel_density()?)?;
+    set_tracked(globals, "pixel_width", surface.pixel_width()?)?;
+    set_tracked(globals, "pixel_height", surface.pixel_height()?)?;
+
+    let (dw, dh) = match monitor::primary()? {
+        Some(m) => (m.width()?, m.height()?),
+        None => (0, 0),
+    };
+    set_tracked(globals, "display_width", dw)?;
+    set_tracked(globals, "display_height", dh)?;
+    Ok(())
+}

--- a/crates/processing_pyo3/src/time.rs
+++ b/crates/processing_pyo3/src/time.rs
@@ -1,0 +1,20 @@
+use pyo3::{exceptions::PyRuntimeError, prelude::*};
+
+pub fn frame_count() -> PyResult<u32> {
+    processing::prelude::frame_count().map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+}
+
+pub fn delta_time() -> PyResult<f32> {
+    processing::prelude::delta_time().map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+}
+
+pub fn elapsed_time() -> PyResult<f32> {
+    processing::prelude::elapsed_time().map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+}
+
+pub fn sync_globals(globals: &Bound<'_, PyAny>) -> PyResult<()> {
+    crate::set_tracked(globals, "frame_count", frame_count()?)?;
+    crate::set_tracked(globals, "delta_time", delta_time()?)?;
+    crate::set_tracked(globals, "elapsed_time", elapsed_time()?)?;
+    Ok(())
+}

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -8,9 +8,11 @@ pub mod graphics;
 pub mod image;
 pub mod light;
 pub mod material;
+pub mod monitor;
 pub mod render;
 pub mod sketch;
 pub(crate) mod surface;
+pub mod time;
 pub mod transform;
 
 use std::path::PathBuf;
@@ -1304,6 +1306,117 @@ pub fn material_destroy(entity: Entity) -> error::Result<()> {
         app.world_mut()
             .run_system_cached_with(material::destroy, entity)
             .unwrap()
+    })
+}
+
+pub fn surface_focused(entity: Entity) -> error::Result<bool> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::focused, entity)
+            .unwrap())
+    })
+}
+
+pub fn surface_scale_factor(entity: Entity) -> error::Result<f32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::scale_factor, entity)
+            .unwrap())
+    })
+}
+
+pub fn surface_physical_width(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::physical_width, entity)
+            .unwrap())
+    })
+}
+
+pub fn surface_physical_height(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::physical_height, entity)
+            .unwrap())
+    })
+}
+
+pub fn monitor_list() -> error::Result<Vec<Entity>> {
+    app_mut(|app| Ok(app.world_mut().run_system_cached(monitor::list).unwrap()))
+}
+
+pub fn monitor_primary() -> error::Result<Option<Entity>> {
+    app_mut(|app| Ok(app.world_mut().run_system_cached(monitor::primary).unwrap()))
+}
+
+pub fn monitor_width(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(monitor::width, entity)
+            .unwrap())
+    })
+}
+
+pub fn monitor_height(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(monitor::height, entity)
+            .unwrap())
+    })
+}
+
+pub fn monitor_scale_factor(entity: Entity) -> error::Result<f64> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(monitor::scale_factor, entity)
+            .unwrap())
+    })
+}
+
+pub fn monitor_refresh_rate_millihertz(entity: Entity) -> error::Result<Option<u32>> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(monitor::refresh_rate_millihertz, entity)
+            .unwrap())
+    })
+}
+
+pub fn monitor_name(entity: Entity) -> error::Result<Option<String>> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(monitor::name, entity)
+            .unwrap())
+    })
+}
+
+pub fn frame_count() -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached(time::frame_count)
+            .unwrap())
+    })
+}
+
+pub fn delta_time() -> error::Result<f32> {
+    app_mut(|app| Ok(app.world_mut().run_system_cached(time::delta_secs).unwrap()))
+}
+
+pub fn elapsed_time() -> error::Result<f32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached(time::elapsed_secs)
+            .unwrap())
     })
 }
 

--- a/crates/processing_render/src/monitor.rs
+++ b/crates/processing_render/src/monitor.rs
@@ -1,0 +1,33 @@
+use bevy::prelude::*;
+use bevy::window::{Monitor, PrimaryMonitor};
+
+pub fn list(query: Query<Entity, With<Monitor>>) -> Vec<Entity> {
+    query.iter().collect()
+}
+
+pub fn primary(query: Query<Entity, With<PrimaryMonitor>>) -> Option<Entity> {
+    query.iter().next()
+}
+
+pub fn width(In(entity): In<Entity>, query: Query<&Monitor>) -> u32 {
+    query.get(entity).map(|m| m.physical_width).unwrap_or(0)
+}
+
+pub fn height(In(entity): In<Entity>, query: Query<&Monitor>) -> u32 {
+    query.get(entity).map(|m| m.physical_height).unwrap_or(0)
+}
+
+pub fn scale_factor(In(entity): In<Entity>, query: Query<&Monitor>) -> f64 {
+    query.get(entity).map(|m| m.scale_factor).unwrap_or(1.0)
+}
+
+pub fn refresh_rate_millihertz(In(entity): In<Entity>, query: Query<&Monitor>) -> Option<u32> {
+    query
+        .get(entity)
+        .ok()
+        .and_then(|m| m.refresh_rate_millihertz)
+}
+
+pub fn name(In(entity): In<Entity>, query: Query<&Monitor>) -> Option<String> {
+    query.get(entity).ok().and_then(|m| m.name.clone())
+}

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -392,3 +392,28 @@ pub fn set_pixel_density(
         Err(error::ProcessingError::SurfaceNotFound)
     }
 }
+
+pub fn focused(In(entity): In<Entity>, query: Query<&Window>) -> bool {
+    query.get(entity).map(|w| w.focused).unwrap_or(false)
+}
+
+pub fn scale_factor(In(entity): In<Entity>, query: Query<&Window>) -> f32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.scale_factor())
+        .unwrap_or(1.0)
+}
+
+pub fn physical_width(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.physical_width())
+        .unwrap_or(0)
+}
+
+pub fn physical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.physical_height())
+        .unwrap_or(0)
+}

--- a/crates/processing_render/src/time.rs
+++ b/crates/processing_render/src/time.rs
@@ -1,0 +1,15 @@
+use bevy::diagnostic::FrameCount;
+use bevy::prelude::*;
+use bevy::time::Time;
+
+pub fn frame_count(count: Option<Res<FrameCount>>) -> u32 {
+    count.map(|c| c.0).unwrap_or(0)
+}
+
+pub fn delta_secs(time: Option<Res<Time>>) -> f32 {
+    time.map(|t| t.delta_secs()).unwrap_or(0.0)
+}
+
+pub fn elapsed_secs(time: Option<Res<Time>>) -> f32 {
+    time.map(|t| t.elapsed_secs()).unwrap_or(0.0)
+}


### PR DESCRIPTION
In Processing, globals and callbacks like `width`, `height`, `mousePressed`, etc. are members of the containing `PApplet` that the user's sketch runs in. This means that inside the user's draw function, the user can simply write `width` due to the elision of the `this` receiver in Java. Further, the draw loop can delegate callbacks to overrides on the user's `PApplet`.

In Python, this is problematic. For stylistic reasons, we do not want to have draw/setup require accepting a `self` receiver, as this would require writing `self.width` etc. anywhere the user wishes to access some Processing state. As such, in Python, we instead do a bit of magic in order make some global variables provide the same semantics as Processing.

This PR provides the following related changes to help support this:

1. Adds a pattern around global variable updates to avoid overwriting user variables that may shadow our variable's names.
2. Support for importing our main module as an alias, i.e. `import mewnala as mn` where `mn.width` delegates to the underlying getter via `__getattr__`.
3. Callback functionality, where we introspect the global ns for a user's function.
4. Input support to enable knowing when to fire callbacks.
5. Misc surface methods for retrieving surface state.
6. A new monitor API object. We don't support monitor selection fully yet but will in the future.
7. Cleanup for ipython/jupyter hooks to make sure the above work.