### PR TITLE
Reliably clear to default clear color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,6 @@ rand = "0.10.0"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 processing_glfw = { workspace = true, features = ["wayland"] }
 
-[[example]]
-name = "test"
-path = "examples/test.rs"
-
 [patch."https://github.com/bevyengine/bevy"]
 bevy = { git = "https://github.com/processing/bevy", branch = "main" }
 

--- a/crates/processing_render/Cargo.toml
+++ b/crates/processing_render/Cargo.toml
@@ -22,7 +22,6 @@ half = "2.7"
 crossbeam-channel = "0.5"
 processing_core = { workspace = true }
 processing_midi = { workspace = true }
-wgpu = { version = "29.0.1", default-features = false }
 
 [build-dependencies]
 wesl = { workspace = true, features = ["package"] }

--- a/crates/processing_render/Cargo.toml
+++ b/crates/processing_render/Cargo.toml
@@ -22,6 +22,7 @@ half = "2.7"
 crossbeam-channel = "0.5"
 processing_core = { workspace = true }
 processing_midi = { workspace = true }
+wgpu = { version = "29.0.1", default-features = false }
 
 [build-dependencies]
 wesl = { workspace = true, features = ["package"] }

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -15,8 +15,7 @@ use bevy::{
     render::{
         RenderApp,
         render_resource::{
-            CommandEncoderDescriptor, Extent3d, LoadOp, MapMode, Operations, Origin3d, PollType,
-            RenderPassColorAttachment, RenderPassDescriptor, StoreOp, TexelCopyBufferInfo,
+            CommandEncoderDescriptor, Extent3d, MapMode, Origin3d, PollType, TexelCopyBufferInfo,
             TexelCopyBufferLayout, TexelCopyTextureInfo, Texture, TextureFormat, TextureUsages,
         },
         renderer::{RenderDevice, RenderQueue},
@@ -448,16 +447,6 @@ pub fn begin_draw(In(entity): In<Entity>, mut state_query: Query<&mut RenderStat
 }
 
 pub fn flush(app: &mut App, entity: Entity) -> Result<()> {
-    // f there's nothing to render, skip the whole render pass. this avoids some issues on
-    // macos with msaa resolve where nothing is rendered
-    let is_empty = graphics_mut!(app, entity)
-        .get::<CommandBuffer>()
-        .map(|c| c.commands.is_empty())
-        .unwrap_or(true);
-    if is_empty {
-        return Ok(());
-    }
-
     graphics_mut!(app, entity).insert(Flush);
     app.update();
     graphics_mut!(app, entity).remove::<Flush>();
@@ -494,49 +483,15 @@ pub fn end_draw(app: &mut App, entity: Entity) -> Result<()> {
 ///
 // TODO: why is metal particularly affected by this? can we remove this?
 pub fn warmup(app: &mut App, entity: Entity) -> Result<()> {
-    let main_texture = {
-        let render_world = app.sub_app_mut(RenderApp).world_mut();
-        let mut query = render_world.query::<(&MainEntity, &ViewTarget)>();
-        let mut found = None;
-        for (main_entity, vt) in query.iter(render_world) {
-            if **main_entity == entity {
-                found = Some(vt.main_texture().clone());
-                break;
-            }
-        }
-        found.ok_or(ProcessingError::GraphicsNotFound)?
-    };
-
-    let render_app = app.sub_app(RenderApp);
-    let render_device = render_app.world().resource::<RenderDevice>();
-    let render_queue = render_app.world().resource::<RenderQueue>();
-
-    let view = main_texture.create_view(&bevy::render::render_resource::TextureViewDescriptor {
-        label: Some("processing_warmup_view"),
-        ..Default::default()
-    });
-    let mut encoder = render_device.create_command_encoder(&CommandEncoderDescriptor {
-        label: Some("processing_warmup_encoder"),
-    });
-    {
-        let _pass = encoder.begin_render_pass(&RenderPassDescriptor {
-            label: Some("processing_warmup_clear"),
-            color_attachments: &[Some(RenderPassColorAttachment {
-                view: &view,
-                depth_slice: None,
-                resolve_target: None,
-                ops: Operations {
-                    load: LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                    store: StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        });
+    for _ in 0..3 {
+        app.world_mut()
+            .run_system_cached_with(
+                record_command,
+                (entity, DrawCommand::BackgroundColor(DEFAULT_CLEAR_COLOR)),
+            )
+            .unwrap()?;
+        flush(app, entity)?;
     }
-    render_queue.submit([encoder.finish()]);
     Ok(())
 }
 

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -486,13 +486,12 @@ pub fn end_draw(app: &mut App, entity: Entity) -> Result<()> {
     present(app, entity)
 }
 
-
-/// Do some work on the GPU to ensure that the render target texture is initialized and can be read 
+/// Do some work on the GPU to ensure that the render target texture is initialized and can be read
 /// from/written to.
-/// 
-/// This is necessary on some platforms (notably macOS) to avoid issues with the first few frames of 
+///
+/// This is necessary on some platforms (notably macOS) to avoid issues with the first few frames of
 /// rendering being corrupted or not appearing at all.
-/// 
+///
 // TODO: why is metal particularly affected by this? can we remove this?
 pub fn warmup(app: &mut App, entity: Entity) -> Result<()> {
     let main_texture = {

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -15,7 +15,8 @@ use bevy::{
     render::{
         RenderApp,
         render_resource::{
-            CommandEncoderDescriptor, Extent3d, MapMode, Origin3d, PollType, TexelCopyBufferInfo,
+            CommandEncoderDescriptor, Extent3d, LoadOp, MapMode, Operations, Origin3d, PollType,
+            RenderPassColorAttachment, RenderPassDescriptor, StoreOp, TexelCopyBufferInfo,
             TexelCopyBufferLayout, TexelCopyTextureInfo, Texture, TextureFormat, TextureUsages,
         },
         renderer::{RenderDevice, RenderQueue},
@@ -35,6 +36,8 @@ use crate::{
     surface::Surface,
 };
 use processing_core::error::{ProcessingError, Result};
+
+pub const DEFAULT_CLEAR_COLOR: Color = Color::srgba_u8(208, 208, 208, 255);
 
 pub struct GraphicsPlugin;
 
@@ -481,6 +484,61 @@ pub fn present(app: &mut App, entity: Entity) -> Result<()> {
 /// End the current draw
 pub fn end_draw(app: &mut App, entity: Entity) -> Result<()> {
     present(app, entity)
+}
+
+
+/// Do some work on the GPU to ensure that the render target texture is initialized and can be read 
+/// from/written to.
+/// 
+/// This is necessary on some platforms (notably macOS) to avoid issues with the first few frames of 
+/// rendering being corrupted or not appearing at all.
+/// 
+// TODO: why is metal particularly affected by this? can we remove this?
+pub fn warmup(app: &mut App, entity: Entity) -> Result<()> {
+    let main_texture = {
+        let render_world = app.sub_app_mut(RenderApp).world_mut();
+        let mut query = render_world.query::<(&MainEntity, &ViewTarget)>();
+        let mut found = None;
+        for (main_entity, vt) in query.iter(render_world) {
+            if **main_entity == entity {
+                found = Some(vt.main_texture().clone());
+                break;
+            }
+        }
+        found.ok_or(ProcessingError::GraphicsNotFound)?
+    };
+
+    let render_app = app.sub_app(RenderApp);
+    let render_device = render_app.world().resource::<RenderDevice>();
+    let render_queue = render_app.world().resource::<RenderQueue>();
+
+    let view = main_texture.create_view(&bevy::render::render_resource::TextureViewDescriptor {
+        label: Some("processing_warmup_view"),
+        ..Default::default()
+    });
+    let mut encoder = render_device.create_command_encoder(&CommandEncoderDescriptor {
+        label: Some("processing_warmup_encoder"),
+    });
+    {
+        let _pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("processing_warmup_clear"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: &view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+    }
+    render_queue.submit([encoder.finish()]);
+    Ok(())
 }
 
 pub fn record_command(

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -27,7 +27,7 @@ use processing_core::config::*;
 use processing_core::error;
 
 use crate::geometry::{AttributeFormat, AttributeValue};
-use crate::graphics::flush;
+use crate::graphics::{DEFAULT_CLEAR_COLOR, flush};
 use crate::image::gpu_image;
 use crate::render::command::DrawCommand;
 
@@ -254,13 +254,26 @@ pub fn graphics_create(
     height: u32,
     texture_format: TextureFormat,
 ) -> error::Result<Entity> {
-    app_mut(|app| {
-        app.world_mut()
+    app_mut(|app| -> error::Result<Entity> {
+        let entity = app
+            .world_mut()
             .run_system_cached_with(
                 graphics::create,
                 (width, height, surface_entity, texture_format),
             )
-            .unwrap()
+            .unwrap()?;
+
+        app.update();
+        #[cfg(target_os = "macos")]
+        graphics::warmup(app, entity)?;
+
+        app.world_mut()
+            .run_system_cached_with(
+                graphics::record_command,
+                (entity, DrawCommand::BackgroundColor(DEFAULT_CLEAR_COLOR)),
+            )
+            .unwrap()?;
+        Ok(entity)
     })
 }
 

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -263,16 +263,7 @@ pub fn graphics_create(
             )
             .unwrap()?;
 
-        app.update();
-        #[cfg(target_os = "macos")]
         graphics::warmup(app, entity)?;
-
-        app.world_mut()
-            .run_system_cached_with(
-                graphics::record_command,
-                (entity, DrawCommand::BackgroundColor(DEFAULT_CLEAR_COLOR)),
-            )
-            .unwrap()?;
         Ok(entity)
     })
 }

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -27,7 +27,7 @@ use processing_core::config::*;
 use processing_core::error;
 
 use crate::geometry::{AttributeFormat, AttributeValue};
-use crate::graphics::{DEFAULT_CLEAR_COLOR, flush};
+use crate::graphics::flush;
 use crate::image::gpu_image;
 use crate::render::command::DrawCommand;
 


### PR DESCRIPTION
Fixes #134 

Metal on wgpu seems to reliably have issues with persisting the first render pass on a texture. We have a workaround here to ensure that we do some work on the texture before our "real" frame 0, which is typically the user's setup function.