### PR TITLE
Fix X11 support and add floating window hint for tiling WMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5695,6 +5695,7 @@ dependencies = [
  "processing_core",
  "processing_input",
  "processing_render",
+ "x11",
 ]
 
 [[package]]
@@ -8262,6 +8263,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11-dl"

--- a/crates/processing_glfw/Cargo.toml
+++ b/crates/processing_glfw/Cargo.toml
@@ -8,10 +8,11 @@ workspace = true
 
 [features]
 wayland = ["glfw/wayland"]
-x11 = []
+x11 = ["dep:x11"]
 static-link = ["glfw/static-link"]
 
 [dependencies]
+x11 = { version = "2", features = ["xlib"], optional = true }
 bevy = { workspace = true }
 glfw = "0.60.0"
 processing_core = { workspace = true }

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -70,6 +70,35 @@ impl GlfwContext {
             .unwrap();
 
         window.set_all_polling(true);
+
+        // Set _NET_WM_WINDOW_TYPE_DIALOG so tiling WMs (i3, sway) float the window
+        #[cfg(all(target_os = "linux", feature = "x11"))]
+        unsafe {
+            use std::ffi::CString;
+            let display = window.glfw.get_x11_display() as *mut x11::xlib::Display;
+            let xwindow = window.get_x11_window() as x11::xlib::Window;
+            let net_wm_window_type = x11::xlib::XInternAtom(
+                display,
+                CString::new("_NET_WM_WINDOW_TYPE").unwrap().as_ptr(),
+                0,
+            );
+            let net_wm_window_type_dialog = x11::xlib::XInternAtom(
+                display,
+                CString::new("_NET_WM_WINDOW_TYPE_DIALOG").unwrap().as_ptr(),
+                0,
+            );
+            x11::xlib::XChangeProperty(
+                display,
+                xwindow,
+                net_wm_window_type,
+                x11::xlib::XA_ATOM,
+                32,
+                x11::xlib::PropModeReplace,
+                &net_wm_window_type_dialog as *const _ as *const u8,
+                1,
+            );
+        }
+
         window.show();
 
         Ok(Self {

--- a/crates/processing_pyo3/Cargo.toml
+++ b/crates/processing_pyo3/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 default = ["wayland", "static-link"]
 wayland = ["processing/wayland", "processing_glfw/wayland"]
 static-link = ["processing_glfw/static-link"]
-x11 = ["processing/x11"]
+x11 = ["processing/x11", "processing_glfw/x11"]
 webcam = ["processing/webcam", "dep:processing_webcam"]
 cuda = ["dep:processing_cuda", "processing_cuda/cuda", "processing/cuda"]
 


### PR DESCRIPTION
**Problem**

mewnala crashes on X11 systems with `GLFW Error: Wayland: Platform not initialized` even when building from source with `--features x11`.

**Root cause**

The `x11` feature in `processing_pyo3/Cargo.toml` was only passing it to `processing` but not to `processing_glfw`, so GLFW never actually got built with X11 support.

**What I changed**

- `processing_pyo3/Cargo.toml` : added `processing_glfw/x11` to the x11 feature
- `processing_glfw/Cargo.toml` : added the `x11` crate as an optional dependency
- `processing_glfw/src/lib.rs` : set `_NET_WM_WINDOW_TYPE_DIALOG` on X11 so tiling WMs like i3 and sway automatically float the window instead of tiling it

**Note**

X11 users still need to build with `--no-default-features --features x11,static-link` for now. Wayland is still the default.

**Tested on**

Arch Linux, i3/X11, AMD Radeon RX 6600 XT