### PR TITLE
Fix window resize stretching the canvas instead of resizing the sketch surface (#127)

### DIFF
--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -359,6 +359,9 @@ impl GlfwContext {
             Ok(())
         });
         self.last_applied.position = frame_pos;
+
+        let (w, h) = self.window.get_size();
+        self.last_applied.size = bevy::math::UVec2::new(w.max(0) as u32, h.max(0) as u32);
     }
 
     #[cfg(not(feature = "wayland"))]

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -13,7 +13,7 @@ use processing_core::error::Result;
 use processing_input::{
     input_cursor_grab_mode, input_cursor_visible, input_flush, input_set_char,
     input_set_cursor_enter, input_set_cursor_leave, input_set_focus, input_set_key,
-    input_set_mouse_button, input_set_mouse_move, input_set_scroll,
+    input_set_mouse_button, input_set_mouse_move, input_set_scroll, input_window_resize,
 };
 use processing_render::surface::{MonitorWorkarea, WindowControls};
 
@@ -256,6 +256,7 @@ impl GlfwContext {
             }
         };
 
+        let mut pending_resize: Option<(i32, i32)> = None;
         for (_, event) in glfw::flush_messages(&self.events) {
             match event {
                 WindowEvent::Close => {
@@ -301,8 +302,8 @@ impl GlfwContext {
                     input_set_focus(surface, focused).unwrap();
                 }
                 WindowEvent::Size(width, height) => {
-                    processing_render::surface_resize(surface, width as u32, height as u32)
-                        .unwrap();
+                    // A drag delivers many Size events per poll; keep only the last and apply it once after the loop.
+                    pending_resize = Some((width, height));
                 }
                 _ => {}
             }
@@ -311,6 +312,12 @@ impl GlfwContext {
         if self.window.should_close() {
             self.window.hide();
             return false;
+        }
+
+        // Apply the coalesced resize once, the WindowResized message and Window change are processed this poll.
+        if let Some((width, height)) = pending_resize {
+            input_window_resize(surface, width as f32, height as f32).unwrap();
+            processing_render::surface_resize(surface, width as u32, height as u32).unwrap();
         }
 
         let Ok(_) = input_flush() else {

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -300,6 +300,14 @@ impl GlfwContext {
                 WindowEvent::Focus(focused) => {
                     input_set_focus(surface, focused).unwrap();
                 }
+                WindowEvent::Size(width, height) => {
+                    processing_render::surface_resize(
+                        surface,
+                        width.max(1) as u32,
+                        height.max(1) as u32,
+                    )
+                    .unwrap();
+                }
                 _ => {}
             }
         }
@@ -355,6 +363,9 @@ impl GlfwContext {
             Ok(())
         });
         self.last_applied.position = frame_pos;
+
+        let (w, h) = self.window.get_size();
+        self.last_applied.size = bevy::math::UVec2::new(w.max(0) as u32, h.max(0) as u32);
     }
 
     #[cfg(not(feature = "wayland"))]
@@ -529,8 +540,8 @@ fn read_desired_window(surface: Entity) -> Option<DesiredWindow> {
                 _ => None,
             },
             size: bevy::math::UVec2::new(
-                window.resolution.physical_width(),
-                window.resolution.physical_height(),
+                window.resolution.width() as u32,
+                window.resolution.height() as u32,
             ),
             visible: window.visible,
             resizable: window.resizable,

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -301,12 +301,8 @@ impl GlfwContext {
                     input_set_focus(surface, focused).unwrap();
                 }
                 WindowEvent::Size(width, height) => {
-                    processing_render::surface_resize(
-                        surface,
-                        width.max(1) as u32,
-                        height.max(1) as u32,
-                    )
-                    .unwrap();
+                    processing_render::surface_resize(surface, width as u32, height as u32)
+                        .unwrap();
                 }
                 _ => {}
             }

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -300,6 +300,19 @@ impl GlfwContext {
                 WindowEvent::Focus(focused) => {
                     input_set_focus(surface, focused).unwrap();
                 }
+                WindowEvent::Size(width, height) => {
+                    let scale = self.content_scale();
+                    let logical_w = ((width as f32) / scale).max(1.0) as i32;
+                    let logical_h = ((height as f32) / scale).max(1.0) as i32;
+                    if logical_w != width || logical_h != height {
+                        // processing_render::surface_resize(
+                        //     surface,
+                        //     logical_w as u32,
+                        //     logical_h as u32,
+                        // )
+                        // .unwrap();
+                    }
+                }
                 _ => {}
             }
         }

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -301,8 +301,12 @@ impl GlfwContext {
                     input_set_focus(surface, focused).unwrap();
                 }
                 WindowEvent::Size(width, height) => {
-                    processing_render::surface_resize(surface, width.max(1) as u32, height.max(1) as u32)
-                        .unwrap();
+                    processing_render::surface_resize(
+                        surface,
+                        width.max(1) as u32,
+                        height.max(1) as u32,
+                    )
+                    .unwrap();
                 }
                 _ => {}
             }

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -304,14 +304,11 @@ impl GlfwContext {
                     let scale = self.content_scale();
                     let logical_w = ((width as f32) / scale).max(1.0) as i32;
                     let logical_h = ((height as f32) / scale).max(1.0) as i32;
-                    if logical_w != width || logical_h != height {
-                        // processing_render::surface_resize(
-                        //     surface,
-                        //     logical_w as u32,
-                        //     logical_h as u32,
-                        // )
-                        // .unwrap();
-                    }
+                    processing_render::surface_resize(
+                        surface,
+                        logical_w as u32,
+                        logical_h as u32,
+                    ).unwrap();
                 }
                 _ => {}
             }

--- a/crates/processing_glfw/src/lib.rs
+++ b/crates/processing_glfw/src/lib.rs
@@ -301,14 +301,8 @@ impl GlfwContext {
                     input_set_focus(surface, focused).unwrap();
                 }
                 WindowEvent::Size(width, height) => {
-                    let scale = self.content_scale();
-                    let logical_w = ((width as f32) / scale).max(1.0) as i32;
-                    let logical_h = ((height as f32) / scale).max(1.0) as i32;
-                    processing_render::surface_resize(
-                        surface,
-                        logical_w as u32,
-                        logical_h as u32,
-                    ).unwrap();
+                    processing_render::surface_resize(surface, width.max(1) as u32, height.max(1) as u32)
+                        .unwrap();
                 }
                 _ => {}
             }
@@ -539,8 +533,8 @@ fn read_desired_window(surface: Entity) -> Option<DesiredWindow> {
                 _ => None,
             },
             size: bevy::math::UVec2::new(
-                window.resolution.physical_width(),
-                window.resolution.physical_height(),
+                window.resolution.width() as u32,
+                window.resolution.height() as u32,
             ),
             visible: window.visible,
             resizable: window.resizable,

--- a/crates/processing_input/src/lib.rs
+++ b/crates/processing_input/src/lib.rs
@@ -8,7 +8,7 @@ use bevy::input::mouse::{
 };
 use bevy::input::touch::TouchPhase;
 use bevy::prelude::*;
-use bevy::window::CursorMoved;
+use bevy::window::{CursorMoved, WindowResized};
 
 use processing_core::app_mut;
 use processing_core::error;
@@ -340,5 +340,16 @@ pub fn input_mouse_scrolled() -> error::Result<bool> {
     app_mut(|app| {
         let d = app.world().resource::<AccumulatedMouseScroll>().delta;
         Ok(d.x != 0.0 || d.y != 0.0)
+    })
+}
+
+pub fn input_window_resize(surface: Entity, width: f32, height: f32) -> error::Result<()> {
+    app_mut(|app| {
+        app.world_mut().write_message(WindowResized {
+            window: surface,
+            width,
+            height,
+        });
+        Ok(())
     })
 }

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -34,7 +34,6 @@ use graphics::{
 };
 use material::Material;
 
-use processing_render::surface_logical_width;
 use pyo3::{
     BoundObject,
     exceptions::PyRuntimeError,
@@ -121,9 +120,9 @@ pub(crate) fn reset_tracked_globals() {
 fn sync_globals(module: &Bound<'_, PyModule>, globals: &Bound<'_, PyAny>) -> PyResult<()> {
     let graphics =
         get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-    let width = ::processing::prelude::surface_logical_width(graphics.surface.entity)
+    let width = ::processing::prelude::surface_width(graphics.surface.entity)
         .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-    let height = ::processing::prelude::surface_logical_height(graphics.surface.entity)
+    let height = ::processing::prelude::surface_height(graphics.surface.entity)
         .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
     input::sync_globals(globals, graphics.surface.entity, width, height)?;
     surface::sync_globals(globals, &graphics.surface, width, height)?;

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -34,6 +34,7 @@ use graphics::{
 };
 use material::Material;
 
+use processing_render::surface_logical_width;
 use pyo3::{
     BoundObject,
     exceptions::PyRuntimeError,
@@ -120,13 +121,14 @@ pub(crate) fn reset_tracked_globals() {
 fn sync_globals(module: &Bound<'_, PyModule>, globals: &Bound<'_, PyAny>) -> PyResult<()> {
     let graphics =
         get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-    input::sync_globals(
-        globals,
-        graphics.surface.entity,
-        graphics.width,
-        graphics.height,
-    )?;
-    surface::sync_globals(globals, &graphics.surface, graphics.width, graphics.height)?;
+    // let width = ::processing::prelude::surface_logical_width(graphics.surface.entity)
+    //     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    // let height = ::processing::prelude::surface_logical_height(graphics.surface.entity)
+    //     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    let width = graphics.width;
+    let height = graphics.height;
+    input::sync_globals(globals, graphics.surface.entity, width, height)?;
+    surface::sync_globals(globals, &graphics.surface, width, height)?;
     time::sync_globals(globals)?;
     Ok(())
 }

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -120,13 +120,12 @@ pub(crate) fn reset_tracked_globals() {
 fn sync_globals(module: &Bound<'_, PyModule>, globals: &Bound<'_, PyAny>) -> PyResult<()> {
     let graphics =
         get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-    input::sync_globals(
-        globals,
-        graphics.surface.entity,
-        graphics.width,
-        graphics.height,
-    )?;
-    surface::sync_globals(globals, &graphics.surface, graphics.width, graphics.height)?;
+    let width = ::processing::prelude::surface_width(graphics.surface.entity)
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    let height = ::processing::prelude::surface_height(graphics.surface.entity)
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    input::sync_globals(globals, graphics.surface.entity, width, height)?;
+    surface::sync_globals(globals, &graphics.surface, width, height)?;
     time::sync_globals(globals)?;
     Ok(())
 }

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -121,12 +121,10 @@ pub(crate) fn reset_tracked_globals() {
 fn sync_globals(module: &Bound<'_, PyModule>, globals: &Bound<'_, PyAny>) -> PyResult<()> {
     let graphics =
         get_graphics(module)?.ok_or_else(|| PyRuntimeError::new_err("call size() first"))?;
-    // let width = ::processing::prelude::surface_logical_width(graphics.surface.entity)
-    //     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-    // let height = ::processing::prelude::surface_logical_height(graphics.surface.entity)
-    //     .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
-    let width = graphics.width;
-    let height = graphics.height;
+    let width = ::processing::prelude::surface_logical_width(graphics.surface.entity)
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
+    let height = ::processing::prelude::surface_logical_height(graphics.surface.entity)
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))?;
     input::sync_globals(globals, graphics.surface.entity, width, height)?;
     surface::sync_globals(globals, &graphics.surface, width, height)?;
     time::sync_globals(globals)?;

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -118,6 +118,8 @@ impl CameraProjection for ProcessingProjection {
         // this gets called with the render target's physical dimensions (i.e. accounting for
         // scale factor), but our projection is in logical pixel units
         // TODO: handle resizes?
+        // self.width = _width;
+        // self.height = _height;
     }
 
     fn far(&self) -> f32 {

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -118,6 +118,8 @@ impl CameraProjection for ProcessingProjection {
         // this gets called with the render target's physical dimensions (i.e. accounting for
         // scale factor), but our projection is in logical pixel units
         // TODO: handle resizes?
+        self.width = _width;
+        self.height = _height;
     }
 
     fn far(&self) -> f32 {

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -22,7 +22,7 @@ use bevy::{
         sync_world::MainEntity,
         view::ViewTarget,
     },
-    window::{WindowRef, WindowResized},
+    window::WindowRef,
 };
 
 use crate::{
@@ -260,7 +260,6 @@ pub fn sync_to_surface(
     mut graphics_query: Query<(&mut Graphics, &RenderTarget)>,
     windows: Query<&Window, (With<Surface>, Changed<Window>)>,
     render_device: Res<RenderDevice>,
-    mut resize_messages: MessageWriter<WindowResized>,
 ) {
     for (mut graphics, target) in graphics_query.iter_mut() {
         let RenderTarget::Window(WindowRef::Entity(surface_entity)) = *target else {
@@ -274,12 +273,6 @@ pub fn sync_to_surface(
         if graphics.size.width == physical_w && graphics.size.height == physical_h {
             continue;
         }
-        //winit plugin disabled, so WindowResized is never triggered automatically
-        resize_messages.write(WindowResized {
-            window: surface_entity,
-            width: window.width(),
-            height: window.height(),
-        });
         graphics.size = Extent3d {
             width: physical_w,
             height: physical_h,

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -22,7 +22,7 @@ use bevy::{
         sync_world::MainEntity,
         view::ViewTarget,
     },
-    window::WindowRef,
+    window::{WindowRef, WindowResized},
 };
 
 use crate::{
@@ -260,6 +260,7 @@ pub fn sync_to_surface(
     mut graphics_query: Query<(&mut Graphics, &RenderTarget)>,
     windows: Query<&Window, (With<Surface>, Changed<Window>)>,
     render_device: Res<RenderDevice>,
+    mut resize_messages: MessageWriter<WindowResized>,
 ) {
     for (mut graphics, target) in graphics_query.iter_mut() {
         let RenderTarget::Window(WindowRef::Entity(surface_entity)) = *target else {
@@ -273,6 +274,12 @@ pub fn sync_to_surface(
         if graphics.size.width == physical_w && graphics.size.height == physical_h {
             continue;
         }
+        //winit plugin disabled, so WindowResized is never triggered automatically
+        resize_messages.write(WindowResized {
+            window: surface_entity,
+            width: window.width(),
+            height: window.height(),
+        });
         graphics.size = Extent3d {
             width: physical_w,
             height: physical_h,

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -117,7 +117,6 @@ impl CameraProjection for ProcessingProjection {
     fn update(&mut self, _width: f32, _height: f32) {
         // this gets called with the render target's physical dimensions (i.e. accounting for
         // scale factor), but our projection is in logical pixel units
-        // TODO: handle resizes?
         self.width = _width;
         self.height = _height;
     }

--- a/crates/processing_render/src/graphics.rs
+++ b/crates/processing_render/src/graphics.rs
@@ -118,8 +118,8 @@ impl CameraProjection for ProcessingProjection {
         // this gets called with the render target's physical dimensions (i.e. accounting for
         // scale factor), but our projection is in logical pixel units
         // TODO: handle resizes?
-        // self.width = _width;
-        // self.height = _height;
+        self.width = _width;
+        self.height = _height;
     }
 
     fn far(&self) -> f32 {

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -1702,6 +1702,24 @@ pub fn surface_physical_height(entity: Entity) -> error::Result<u32> {
     })
 }
 
+pub fn surface_logical_width(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::logical_width, entity)
+            .unwrap())
+    })
+}
+
+pub fn surface_logical_height(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::logical_height, entity)
+            .unwrap())
+    })
+}
+
 pub fn monitor_list() -> error::Result<Vec<Entity>> {
     app_mut(|app| Ok(app.world_mut().run_system_cached(monitor::list).unwrap()))
 }

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -1702,20 +1702,20 @@ pub fn surface_physical_height(entity: Entity) -> error::Result<u32> {
     })
 }
 
-pub fn surface_logical_width(entity: Entity) -> error::Result<u32> {
+pub fn surface_width(entity: Entity) -> error::Result<u32> {
     app_mut(|app| {
         Ok(app
             .world_mut()
-            .run_system_cached_with(surface::logical_width, entity)
+            .run_system_cached_with(surface::width, entity)
             .unwrap())
     })
 }
 
-pub fn surface_logical_height(entity: Entity) -> error::Result<u32> {
+pub fn surface_height(entity: Entity) -> error::Result<u32> {
     app_mut(|app| {
         Ok(app
             .world_mut()
-            .run_system_cached_with(surface::logical_height, entity)
+            .run_system_cached_with(surface::height, entity)
             .unwrap())
     })
 }

--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -1702,6 +1702,24 @@ pub fn surface_physical_height(entity: Entity) -> error::Result<u32> {
     })
 }
 
+pub fn surface_width(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::width, entity)
+            .unwrap())
+    })
+}
+
+pub fn surface_height(entity: Entity) -> error::Result<u32> {
+    app_mut(|app| {
+        Ok(app
+            .world_mut()
+            .run_system_cached_with(surface::height, entity)
+            .unwrap())
+    })
+}
+
 pub fn monitor_list() -> error::Result<Vec<Entity>> {
     app_mut(|app| Ok(app.world_mut().run_system_cached(monitor::list).unwrap()))
 }

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -40,10 +40,7 @@ use processing_core::error::{self, ProcessingError, Result};
 #[cfg(not(target_os = "windows"))]
 use std::ptr::NonNull;
 
-use crate::{
-    graphics::SurfaceSize,
-    image::Image,
-};
+use crate::{graphics::SurfaceSize, image::Image};
 
 #[derive(Component, Debug, Clone)]
 pub struct Surface;
@@ -464,14 +461,14 @@ pub fn physical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
         .unwrap_or(0)
 }
 
-pub fn logical_width(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+pub fn width(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
     query
         .get(entity)
         .map(|w| w.resolution.width() as u32)
         .unwrap_or(0)
 }
 
-pub fn logical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+pub fn height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
     query
         .get(entity)
         .map(|w| w.resolution.height() as u32)

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -412,7 +412,8 @@ pub fn resize(
     // SurfaceSize changes on resize, if not handled will break APIs dependent on correct SurfaceSize
     for (target, mut surface_size) in graphics_query.iter_mut() {
         if let RenderTarget::Window(WindowRef::Entity(surface)) = *target
-            && surface == window_entity {
+            && surface == window_entity
+        {
             *surface_size = SurfaceSize(width, height);
         }
     }

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -21,13 +21,14 @@
 use bevy::{
     app::{App, Plugin},
     asset::Assets,
+    camera::{Projection, RenderTarget},
     ecs::query::QueryEntityError,
     math::{IRect, IVec2},
     prelude::{Commands, Component, Entity, In, Query, ResMut, Window, With, default},
     render::render_resource::{Extent3d, TextureFormat},
     window::{
         CompositeAlphaMode, Monitor, RawHandleWrapper, WindowLevel, WindowMode, WindowPosition,
-        WindowResolution, WindowWrapper,
+        WindowRef, WindowResolution, WindowWrapper,
     },
 };
 use raw_window_handle::{
@@ -39,7 +40,7 @@ use processing_core::error::{self, ProcessingError, Result};
 #[cfg(not(target_os = "windows"))]
 use std::ptr::NonNull;
 
-use crate::image::Image;
+use crate::{graphics::SurfaceSize, image::Image};
 
 #[derive(Component, Debug, Clone)]
 pub struct Surface;
@@ -394,6 +395,7 @@ pub fn destroy(
 pub fn resize(
     In((window_entity, width, height)): In<(Entity, u32, u32)>,
     mut windows: Query<&mut Window>,
+    mut graphics_query: Query<(&RenderTarget, &mut SurfaceSize, &mut Projection)>,
 ) -> Result<()> {
     if let Ok(mut window) = windows.get_mut(window_entity) {
         let scale = window.resolution.scale_factor();
@@ -402,6 +404,17 @@ pub fn resize(
         window
             .resolution
             .set_physical_resolution(physical_w, physical_h);
+    }
+
+    for (target, mut surface_size, mut projection) in graphics_query.iter_mut() {
+        if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
+            if surface == window_entity {
+                *surface_size = SurfaceSize(width, height);
+                if let Projection::Custom(ref mut custom) = *projection {
+                    custom.update(width as f32, height as f32);
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -445,6 +458,20 @@ pub fn physical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
     query
         .get(entity)
         .map(|w| w.resolution.physical_height())
+        .unwrap_or(0)
+}
+
+pub fn width(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.width() as u32)
+        .unwrap_or(0)
+}
+
+pub fn height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.height() as u32)
         .unwrap_or(0)
 }
 

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -21,7 +21,7 @@
 use bevy::{
     app::{App, Plugin},
     asset::Assets,
-    camera::{Projection, RenderTarget},
+    camera::RenderTarget,
     ecs::query::QueryEntityError,
     math::{IRect, IVec2},
     prelude::{Commands, Component, Entity, In, Query, ResMut, Window, With, default},
@@ -395,8 +395,11 @@ pub fn destroy(
 pub fn resize(
     In((window_entity, width, height)): In<(Entity, u32, u32)>,
     mut windows: Query<&mut Window>,
-    mut graphics_query: Query<(&RenderTarget, &mut SurfaceSize, &mut Projection)>,
+    mut graphics_query: Query<(&RenderTarget, &mut SurfaceSize)>,
 ) -> Result<()> {
+    let width = width.max(1);
+    let height = height.max(1);
+
     if let Ok(mut window) = windows.get_mut(window_entity) {
         let scale = window.resolution.scale_factor();
         let physical_w = (width as f32 * scale) as u32;
@@ -405,14 +408,12 @@ pub fn resize(
             .resolution
             .set_physical_resolution(physical_w, physical_h);
     }
-
-    for (target, mut surface_size, mut projection) in graphics_query.iter_mut() {
+    
+    // SurfaceSize changes on resize, if not handled will break APIs dependent on correct SurfaceSize
+    for (target, mut surface_size) in graphics_query.iter_mut() {
         if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
             if surface == window_entity {
                 *surface_size = SurfaceSize(width, height);
-                if let Projection::Custom(ref mut custom) = *projection {
-                    custom.update(width as f32, height as f32);
-                }
             }
         }
     }

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -411,10 +411,9 @@ pub fn resize(
 
     // SurfaceSize changes on resize, if not handled will break APIs dependent on correct SurfaceSize
     for (target, mut surface_size) in graphics_query.iter_mut() {
-        if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
-            if surface == window_entity {
-                *surface_size = SurfaceSize(width, height);
-            }
+        if let RenderTarget::Window(WindowRef::Entity(surface)) = *target
+            && surface == window_entity {
+            *surface_size = SurfaceSize(width, height);
         }
     }
     Ok(())

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -21,13 +21,14 @@
 use bevy::{
     app::{App, Plugin},
     asset::Assets,
+    camera::{CameraProjection, Projection, RenderTarget},
     ecs::query::QueryEntityError,
     math::{IRect, IVec2},
     prelude::{Commands, Component, Entity, In, Query, ResMut, Window, With, default},
     render::render_resource::{Extent3d, TextureFormat},
     window::{
         CompositeAlphaMode, Monitor, RawHandleWrapper, WindowLevel, WindowMode, WindowPosition,
-        WindowResolution, WindowWrapper,
+        WindowRef, WindowResolution, WindowWrapper,
     },
 };
 use raw_window_handle::{
@@ -39,7 +40,10 @@ use processing_core::error::{self, ProcessingError, Result};
 #[cfg(not(target_os = "windows"))]
 use std::ptr::NonNull;
 
-use crate::image::Image;
+use crate::{
+    graphics::{ProcessingProjection, SurfaceSize},
+    image::Image,
+};
 
 #[derive(Component, Debug, Clone)]
 pub struct Surface;
@@ -394,7 +398,19 @@ pub fn destroy(
 pub fn resize(
     In((window_entity, width, height)): In<(Entity, u32, u32)>,
     mut windows: Query<&mut Window>,
+    mut graphics_query: Query<(&RenderTarget, &mut SurfaceSize, &mut Projection)>,
 ) -> Result<()> {
+    let width = width.max(1);
+    let height = height.max(1);
+
+    // let Ok(window) = windows.get_mut(window_entity) else {
+    //     return Ok(());
+    // };
+    //
+    // if window.mode != WindowMode::Windowed {
+    //     return Ok(());
+    // }
+
     if let Ok(mut window) = windows.get_mut(window_entity) {
         let scale = window.resolution.scale_factor();
         let physical_w = (width as f32 * scale) as u32;
@@ -403,6 +419,17 @@ pub fn resize(
             .resolution
             .set_physical_resolution(physical_w, physical_h);
     }
+
+    // for (target, mut surface_size, mut projection) in graphics_query.iter_mut() {
+    //     if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
+    //         if surface == window_entity {
+    //             *surface_size = SurfaceSize(width, height);
+    //             if let Projection::Custom(ref mut custom) = *projection {
+    //                 custom.update(width as f32, height as f32);
+    //             }
+    //         }
+    //     }
+    // }
     Ok(())
 }
 
@@ -445,6 +472,20 @@ pub fn physical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
     query
         .get(entity)
         .map(|w| w.resolution.physical_height())
+        .unwrap_or(0)
+}
+
+pub fn logical_width(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.width() as u32)
+        .unwrap_or(0)
+}
+
+pub fn logical_height(In(entity): In<Entity>, query: Query<&Window>) -> u32 {
+    query
+        .get(entity)
+        .map(|w| w.resolution.height() as u32)
         .unwrap_or(0)
 }
 

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -403,14 +403,6 @@ pub fn resize(
     let width = width.max(1);
     let height = height.max(1);
 
-    // let Ok(window) = windows.get_mut(window_entity) else {
-    //     return Ok(());
-    // };
-    //
-    // if window.mode != WindowMode::Windowed {
-    //     return Ok(());
-    // }
-
     if let Ok(mut window) = windows.get_mut(window_entity) {
         let scale = window.resolution.scale_factor();
         let physical_w = (width as f32 * scale) as u32;
@@ -420,16 +412,16 @@ pub fn resize(
             .set_physical_resolution(physical_w, physical_h);
     }
 
-    // for (target, mut surface_size, mut projection) in graphics_query.iter_mut() {
-    //     if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
-    //         if surface == window_entity {
-    //             *surface_size = SurfaceSize(width, height);
-    //             if let Projection::Custom(ref mut custom) = *projection {
-    //                 custom.update(width as f32, height as f32);
-    //             }
-    //         }
-    //     }
-    // }
+    for (target, mut surface_size, mut projection) in graphics_query.iter_mut() {
+        if let RenderTarget::Window(WindowRef::Entity(surface)) = *target {
+            if surface == window_entity {
+                *surface_size = SurfaceSize(width, height);
+                if let Projection::Custom(ref mut custom) = *projection {
+                    custom.update(width as f32, height as f32);
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/processing_render/src/surface.rs
+++ b/crates/processing_render/src/surface.rs
@@ -21,7 +21,7 @@
 use bevy::{
     app::{App, Plugin},
     asset::Assets,
-    camera::{CameraProjection, Projection, RenderTarget},
+    camera::{Projection, RenderTarget},
     ecs::query::QueryEntityError,
     math::{IRect, IVec2},
     prelude::{Commands, Component, Entity, In, Query, ResMut, Window, With, default},
@@ -41,7 +41,7 @@ use processing_core::error::{self, ProcessingError, Result};
 use std::ptr::NonNull;
 
 use crate::{
-    graphics::{ProcessingProjection, SurfaceSize},
+    graphics::SurfaceSize,
     image::Image,
 };
 
@@ -400,9 +400,6 @@ pub fn resize(
     mut windows: Query<&mut Window>,
     mut graphics_query: Query<(&RenderTarget, &mut SurfaceSize, &mut Projection)>,
 ) -> Result<()> {
-    let width = width.max(1);
-    let height = height.max(1);
-
     if let Ok(mut window) = windows.get_mut(window_entity) {
         let scale = window.resolution.scale_factor();
         let physical_w = (width as f32 * scale) as u32;


### PR DESCRIPTION
# Fix: https://github.com/processing/libprocessing/issues/127

Both bugs stem from the same root confusion: **logical vs. physical pixels**. @catilac 

## Summary

Two rendering issues with a shared cause in how window dimensions were
interpreted.

## Fix 1 _Resize stretched the canvas instead of reflowing it_

**Root cause:** Bevy's `WinitPlugin` is disabled (we use a GLFW backend), so
nothing emitted `WindowResized`. Without that event:

- `bevy_render`'s `camera_system` never ran on resize
- the camera's `Projection` stayed pinned to the original size
- the render target was simply scaled to fit — the "stretch"
- `width`/`height` (`SurfaceSize`) were left stale

**Fix:** `input_window_resize` now emits `WindowResized` itself whenever a window's
physical size actually changes.

## Fix 2  _macOS Retina rendered 400×400 sketches as 800×800_

**Root cause:** the camera's `ProcessingProjection` (the sketch's coordinate
space) was built from *physical* dimensions (`width × scale_factor` = 800 on a
2× display) instead of the *logical* size (400), doubling everything.

**Fix:** use logical `width`/`height` for the projection and `SurfaceSize`;
reserve physical dimensions for the GPU texture (`Extent3d`) and readback buffer
only.