### PR TITLE
Fixups for rotation.

### DIFF
--- a/crates/processing_ffi/src/lib.rs
+++ b/crates/processing_ffi/src/lib.rs
@@ -466,24 +466,32 @@ pub extern "C" fn processing_reset_matrix(graphics_id: u64) {
 /// - graphics_id is a valid ID returned from graphics_create.
 /// - This is called from the same thread as init.
 #[unsafe(no_mangle)]
-pub extern "C" fn processing_translate(graphics_id: u64, x: f32, y: f32) {
+pub extern "C" fn processing_translate(graphics_id: u64, x: f32, y: f32, z: f32) {
     error::clear_error();
     let graphics_entity = Entity::from_bits(graphics_id);
     error::check(|| {
-        graphics_record_command(graphics_entity, DrawCommand::Translate(Vec2::new(x, y)))
+        graphics_record_command(graphics_entity, DrawCommand::Translate(Vec3::new(x, y, z)))
     });
 }
 
-/// Rotate the coordinate system.
+/// Rotate the coordinate system by `angle` about the axis (x, y, z).
 ///
 /// SAFETY:
 /// - graphics_id is a valid ID returned from graphics_create.
 /// - This is called from the same thread as init.
 #[unsafe(no_mangle)]
-pub extern "C" fn processing_rotate(graphics_id: u64, angle: f32) {
+pub extern "C" fn processing_rotate(graphics_id: u64, angle: f32, x: f32, y: f32, z: f32) {
     error::clear_error();
     let graphics_entity = Entity::from_bits(graphics_id);
-    error::check(|| graphics_record_command(graphics_entity, DrawCommand::Rotate { angle }));
+    error::check(|| {
+        graphics_record_command(
+            graphics_entity,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::new(x, y, z),
+            },
+        )
+    });
 }
 
 /// Scale the coordinate system.
@@ -492,10 +500,10 @@ pub extern "C" fn processing_rotate(graphics_id: u64, angle: f32) {
 /// - graphics_id is a valid ID returned from graphics_create.
 /// - This is called from the same thread as init.
 #[unsafe(no_mangle)]
-pub extern "C" fn processing_scale(graphics_id: u64, x: f32, y: f32) {
+pub extern "C" fn processing_scale(graphics_id: u64, x: f32, y: f32, z: f32) {
     error::clear_error();
     let graphics_entity = Entity::from_bits(graphics_id);
-    error::check(|| graphics_record_command(graphics_entity, DrawCommand::Scale(Vec2::new(x, y))));
+    error::check(|| graphics_record_command(graphics_entity, DrawCommand::Scale(Vec3::new(x, y, z))));
 }
 
 /// Shear along the X axis.

--- a/crates/processing_ffi/src/lib.rs
+++ b/crates/processing_ffi/src/lib.rs
@@ -503,7 +503,9 @@ pub extern "C" fn processing_rotate(graphics_id: u64, angle: f32, x: f32, y: f32
 pub extern "C" fn processing_scale(graphics_id: u64, x: f32, y: f32, z: f32) {
     error::clear_error();
     let graphics_entity = Entity::from_bits(graphics_id);
-    error::check(|| graphics_record_command(graphics_entity, DrawCommand::Scale(Vec3::new(x, y, z))));
+    error::check(|| {
+        graphics_record_command(graphics_entity, DrawCommand::Scale(Vec3::new(x, y, z)))
+    });
 }
 
 /// Shear along the X axis.

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -1378,23 +1378,47 @@ impl Graphics {
     }
 
     pub fn rotate(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Z })
-            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+        graphics_record_command(
+            self.entity,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_x(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::X })
-            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+        graphics_record_command(
+            self.entity,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::X,
+            },
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_y(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Y })
-            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+        graphics_record_command(
+            self.entity,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Y,
+            },
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_z(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Z })
-            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+        graphics_record_command(
+            self.entity,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )
+        .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     #[pyo3(signature = (angle, *args))]

--- a/crates/processing_pyo3/src/graphics.rs
+++ b/crates/processing_pyo3/src/graphics.rs
@@ -4,7 +4,7 @@ use crate::input;
 use crate::math::{extract_vec2, extract_vec3, extract_vec4};
 use bevy::{
     color::{ColorToPacked, Srgba},
-    math::Vec4,
+    math::{Vec3, Vec4},
     prelude::Entity,
     render::render_resource::{Extent3d, TextureFormat},
 };
@@ -1368,28 +1368,39 @@ impl Graphics {
 
     #[pyo3(signature = (*args))]
     pub fn translate(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
-        let v = extract_vec2(args)?;
+        let v = if args.len() == 3 {
+            extract_vec3(args)?
+        } else {
+            extract_vec2(args)?.extend(0.0)
+        };
         graphics_record_command(self.entity, DrawCommand::Translate(v))
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::Rotate { angle })
+        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Z })
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_x(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::RotateX { angle })
+        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::X })
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_y(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::RotateY { angle })
+        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Y })
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
     pub fn rotate_z(&self, angle: f32) -> PyResult<()> {
-        graphics_record_command(self.entity, DrawCommand::RotateZ { angle })
+        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis: Vec3::Z })
+            .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
+    }
+
+    #[pyo3(signature = (angle, *args))]
+    pub fn rotate_axis(&self, angle: f32, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+        let axis = extract_vec3(args)?;
+        graphics_record_command(self.entity, DrawCommand::Rotate { angle, axis })
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }
 
@@ -1554,7 +1565,16 @@ impl Graphics {
 
     #[pyo3(signature = (*args))]
     pub fn scale(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
-        let v = extract_vec2(args)?;
+        let v = if args.len() == 3 {
+            extract_vec3(args)?
+        } else if args.len() == 1 {
+            match args.get_item(0)?.extract::<f32>() {
+                Ok(s) => Vec3::splat(s),
+                Err(_) => extract_vec2(args)?.extend(1.0),
+            }
+        } else {
+            extract_vec2(args)?.extend(1.0)
+        };
         graphics_record_command(self.entity, DrawCommand::Scale(v))
             .map_err(|e| PyRuntimeError::new_err(format!("{e}")))
     }

--- a/crates/processing_pyo3/src/lib.rs
+++ b/crates/processing_pyo3/src/lib.rs
@@ -1301,6 +1301,16 @@ mod mewnala {
         graphics!(module).rotate_z(angle)
     }
 
+    #[pyfunction]
+    #[pyo3(pass_module, signature = (angle, *args))]
+    fn rotate_axis(
+        module: &Bound<'_, PyModule>,
+        angle: f32,
+        args: &Bound<'_, PyTuple>,
+    ) -> PyResult<()> {
+        graphics!(module).rotate_axis(angle, args)
+    }
+
     #[pyfunction(name = "box")]
     #[pyo3(pass_module, signature = (*args))]
     fn draw_box(module: &Bound<'_, PyModule>, args: &Bound<'_, PyTuple>) -> PyResult<()> {

--- a/crates/processing_render/src/render/command.rs
+++ b/crates/processing_render/src/render/command.rs
@@ -511,20 +511,12 @@ pub enum DrawCommand {
     PushMatrix,
     PopMatrix,
     ResetMatrix,
-    Translate(Vec2),
+    Translate(Vec3),
     Rotate {
         angle: f32,
+        axis: Vec3,
     },
-    RotateX {
-        angle: f32,
-    },
-    RotateY {
-        angle: f32,
-    },
-    RotateZ {
-        angle: f32,
-    },
-    Scale(Vec2),
+    Scale(Vec3),
     ShearX {
         angle: f32,
     },

--- a/crates/processing_render/src/render/mod.rs
+++ b/crates/processing_render/src/render/mod.rs
@@ -929,14 +929,21 @@ pub fn flush_draw_commands(
                 DrawCommand::PushMatrix => state.transform.push(),
                 DrawCommand::PopMatrix => state.transform.pop(),
                 DrawCommand::ResetMatrix => state.transform.reset(),
-                DrawCommand::Translate(v) => state.transform.translate(v.x, v.y),
-                DrawCommand::Rotate { angle } => state.transform.rotate(angle),
-                DrawCommand::RotateX { angle } => state.transform.rotate_x(angle),
-                DrawCommand::RotateY { angle } => state.transform.rotate_y(angle),
-                DrawCommand::RotateZ { angle } => state.transform.rotate_z(angle),
-                DrawCommand::Scale(v) => state.transform.scale(v.x, v.y),
-                DrawCommand::ShearX { angle } => state.transform.shear_x(angle),
-                DrawCommand::ShearY { angle } => state.transform.shear_y(angle),
+                DrawCommand::Translate(v) => {
+                    state.transform.apply(Affine3A::from_translation(v))
+                }
+                DrawCommand::Rotate { angle, axis } => {
+                    state
+                        .transform
+                        .apply(Affine3A::from_axis_angle(axis.normalize(), angle))
+                }
+                DrawCommand::Scale(v) => state.transform.apply(Affine3A::from_scale(v)),
+                DrawCommand::ShearX { angle } => {
+                    state.transform.apply(transform::shear_x(angle))
+                }
+                DrawCommand::ShearY { angle } => {
+                    state.transform.apply(transform::shear_y(angle))
+                }
                 DrawCommand::Geometry(entity) => {
                     let Some((geometry, node_transform)) = p_geometries.get(entity).ok() else {
                         warn!("Could not find Geometry for entity {:?}", entity);
@@ -1268,7 +1275,9 @@ pub fn flush_draw_commands(
                     let text_cx = text_cx.clone();
 
                     if z != 0.0 {
-                        state.transform.translate_3d(0.0, 0.0, z);
+                        state
+                            .transform
+                            .apply(Affine3A::from_translation(Vec3::new(0.0, 0.0, z)));
                     }
 
                     add_fill(
@@ -1305,7 +1314,9 @@ pub fn flush_draw_commands(
                     );
 
                     if z != 0.0 {
-                        state.transform.translate_3d(0.0, 0.0, -z);
+                        state
+                            .transform
+                            .apply(Affine3A::from_translation(Vec3::new(0.0, 0.0, -z)));
                     }
                 }
             }

--- a/crates/processing_render/src/render/mod.rs
+++ b/crates/processing_render/src/render/mod.rs
@@ -929,21 +929,13 @@ pub fn flush_draw_commands(
                 DrawCommand::PushMatrix => state.transform.push(),
                 DrawCommand::PopMatrix => state.transform.pop(),
                 DrawCommand::ResetMatrix => state.transform.reset(),
-                DrawCommand::Translate(v) => {
-                    state.transform.apply(Affine3A::from_translation(v))
-                }
-                DrawCommand::Rotate { angle, axis } => {
-                    state
-                        .transform
-                        .apply(Affine3A::from_axis_angle(axis.normalize(), angle))
-                }
+                DrawCommand::Translate(v) => state.transform.apply(Affine3A::from_translation(v)),
+                DrawCommand::Rotate { angle, axis } => state
+                    .transform
+                    .apply(Affine3A::from_axis_angle(axis.normalize(), angle)),
                 DrawCommand::Scale(v) => state.transform.apply(Affine3A::from_scale(v)),
-                DrawCommand::ShearX { angle } => {
-                    state.transform.apply(transform::shear_x(angle))
-                }
-                DrawCommand::ShearY { angle } => {
-                    state.transform.apply(transform::shear_y(angle))
-                }
+                DrawCommand::ShearX { angle } => state.transform.apply(transform::shear_x(angle)),
+                DrawCommand::ShearY { angle } => state.transform.apply(transform::shear_y(angle)),
                 DrawCommand::Geometry(entity) => {
                     let Some((geometry, node_transform)) = p_geometries.get(entity).ok() else {
                         warn!("Could not find Geometry for entity {:?}", entity);

--- a/crates/processing_render/src/render/transform.rs
+++ b/crates/processing_render/src/render/transform.rs
@@ -1,4 +1,4 @@
-use bevy::math::{Affine3A, Mat3, Quat, Vec3};
+use bevy::math::{Affine3A, Mat3, Vec3};
 
 #[derive(Debug, Clone, Default)]
 pub struct TransformStack {
@@ -34,70 +34,6 @@ impl TransformStack {
         self.stack.clear();
     }
 
-    pub fn translate(&mut self, x: f32, y: f32) {
-        self.translate_3d(x, y, 0.0);
-    }
-
-    pub fn rotate(&mut self, angle: f32) {
-        self.rotate_z(angle);
-    }
-
-    pub fn scale_uniform(&mut self, s: f32) {
-        self.scale(s, s);
-    }
-
-    pub fn scale(&mut self, sx: f32, sy: f32) {
-        self.scale_3d(sx, sy, 1.0);
-    }
-
-    pub fn shear_x(&mut self, angle: f32) {
-        let shear = Affine3A::from_mat3(Mat3::from_cols(
-            Vec3::new(1.0, 0.0, 0.0),
-            Vec3::new(angle.tan(), 1.0, 0.0),
-            Vec3::new(0.0, 0.0, 1.0),
-        ));
-        self.current *= shear;
-    }
-
-    pub fn shear_y(&mut self, angle: f32) {
-        let shear = Affine3A::from_mat3(Mat3::from_cols(
-            Vec3::new(1.0, angle.tan(), 0.0),
-            Vec3::new(0.0, 1.0, 0.0),
-            Vec3::new(0.0, 0.0, 1.0),
-        ));
-        self.current *= shear;
-    }
-
-    pub fn translate_3d(&mut self, x: f32, y: f32, z: f32) {
-        let t = Affine3A::from_translation(Vec3::new(x, y, z));
-        self.current *= t;
-    }
-
-    pub fn rotate_x(&mut self, angle: f32) {
-        let r = Affine3A::from_quat(Quat::from_rotation_x(angle));
-        self.current *= r;
-    }
-
-    pub fn rotate_y(&mut self, angle: f32) {
-        let r = Affine3A::from_quat(Quat::from_rotation_y(angle));
-        self.current *= r;
-    }
-
-    pub fn rotate_z(&mut self, angle: f32) {
-        let r = Affine3A::from_quat(Quat::from_rotation_z(angle));
-        self.current *= r;
-    }
-
-    pub fn rotate_axis(&mut self, angle: f32, axis: Vec3) {
-        let r = Affine3A::from_quat(Quat::from_axis_angle(axis.normalize(), angle));
-        self.current *= r;
-    }
-
-    pub fn scale_3d(&mut self, sx: f32, sy: f32, sz: f32) {
-        let s = Affine3A::from_scale(Vec3::new(sx, sy, sz));
-        self.current *= s;
-    }
-
     pub fn apply(&mut self, transform: Affine3A) {
         self.current *= transform;
     }
@@ -119,6 +55,22 @@ impl TransformStack {
         let p = self.current.transform_point3(Vec3::new(x, y, 0.0));
         (p.x, p.y)
     }
+}
+
+pub fn shear_x(angle: f32) -> Affine3A {
+    Affine3A::from_mat3(Mat3::from_cols(
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(angle.tan(), 1.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+    ))
+}
+
+pub fn shear_y(angle: f32) -> Affine3A {
+    Affine3A::from_mat3(Mat3::from_cols(
+        Vec3::new(1.0, angle.tan(), 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+    ))
 }
 
 #[cfg(test)]
@@ -144,7 +96,7 @@ mod tests {
     #[test]
     fn test_translate() {
         let mut stack = TransformStack::new();
-        stack.translate(100.0, 50.0);
+        stack.apply(Affine3A::from_translation(Vec3::new(100.0, 50.0, 0.0)));
         let (x, y) = stack.transform_point_2d(10.0, 20.0);
         assert!(approx_eq(x, 110.0));
         assert!(approx_eq(y, 70.0));
@@ -153,7 +105,7 @@ mod tests {
     #[test]
     fn test_scale() {
         let mut stack = TransformStack::new();
-        stack.scale(2.0, 3.0);
+        stack.apply(Affine3A::from_scale(Vec3::new(2.0, 3.0, 1.0)));
         let (x, y) = stack.transform_point_2d(10.0, 10.0);
         assert!(approx_eq(x, 20.0));
         assert!(approx_eq(y, 30.0));
@@ -162,7 +114,7 @@ mod tests {
     #[test]
     fn test_rotate_90() {
         let mut stack = TransformStack::new();
-        stack.rotate(PI / 2.0);
+        stack.apply(Affine3A::from_rotation_z(PI / 2.0));
         let (x, y) = stack.transform_point_2d(10.0, 0.0);
         assert!(approx_eq(x, 0.0));
         assert!(approx_eq(y, 10.0));
@@ -171,9 +123,9 @@ mod tests {
     #[test]
     fn test_push_pop() {
         let mut stack = TransformStack::new();
-        stack.translate(100.0, 100.0);
+        stack.apply(Affine3A::from_translation(Vec3::new(100.0, 100.0, 0.0)));
         stack.push();
-        stack.translate(50.0, 50.0);
+        stack.apply(Affine3A::from_translation(Vec3::new(50.0, 50.0, 0.0)));
 
         let (x, y) = stack.transform_point_2d(0.0, 0.0);
         assert!(approx_eq(x, 150.0));
@@ -189,7 +141,7 @@ mod tests {
     #[test]
     fn test_pop_empty_is_noop() {
         let mut stack = TransformStack::new();
-        stack.translate(50.0, 50.0);
+        stack.apply(Affine3A::from_translation(Vec3::new(50.0, 50.0, 0.0)));
         stack.pop();
         let (x, y) = stack.transform_point_2d(0.0, 0.0);
         assert!(approx_eq(x, 50.0));

--- a/crates/processing_wasm/src/lib.rs
+++ b/crates/processing_wasm/src/lib.rs
@@ -314,7 +314,7 @@ pub fn js_translate(graphics_id: u64, x: f32, y: f32) -> Result<(), JsValue> {
     let graphics_entity = Entity::from_bits(graphics_id);
     check(graphics_record_command(
         graphics_entity,
-        DrawCommand::Translate(Vec2::new(x, y)),
+        DrawCommand::Translate(Vec3::new(x, y, 0.0)),
     ))
 }
 
@@ -323,7 +323,10 @@ pub fn js_rotate(graphics_id: u64, angle: f32) -> Result<(), JsValue> {
     let graphics_entity = Entity::from_bits(graphics_id);
     check(graphics_record_command(
         graphics_entity,
-        DrawCommand::Rotate { angle },
+        DrawCommand::Rotate {
+            angle,
+            axis: Vec3::Z,
+        },
     ))
 }
 
@@ -332,7 +335,7 @@ pub fn js_scale(graphics_id: u64, x: f32, y: f32) -> Result<(), JsValue> {
     let graphics_entity = Entity::from_bits(graphics_id);
     check(graphics_record_command(
         graphics_entity,
-        DrawCommand::Scale(Vec2::new(x, y)),
+        DrawCommand::Scale(Vec3::new(x, y, 1.0)),
     ))
 }
 

--- a/examples/box.rs
+++ b/examples/box.rs
@@ -42,7 +42,7 @@ fn sketch() -> error::Result<()> {
         )?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/box.rs
+++ b/examples/box.rs
@@ -42,7 +42,13 @@ fn sketch() -> error::Result<()> {
         )?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/camera_controllers.rs
+++ b/examples/camera_controllers.rs
@@ -70,7 +70,7 @@ fn sketch() -> error::Result<()> {
             graphics_record_command(graphics, DrawCommand::Roughness(0.3))?;
             graphics_record_command(graphics, DrawCommand::Metallic(0.8))?;
             graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-            graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+            graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
             graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
             graphics_record_command(graphics, DrawCommand::PopMatrix)?;
         } else {

--- a/examples/camera_controllers.rs
+++ b/examples/camera_controllers.rs
@@ -70,7 +70,13 @@ fn sketch() -> error::Result<()> {
             graphics_record_command(graphics, DrawCommand::Roughness(0.3))?;
             graphics_record_command(graphics, DrawCommand::Metallic(0.8))?;
             graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-            graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+            graphics_record_command(
+                graphics,
+                DrawCommand::Rotate {
+                    angle,
+                    axis: Vec3::Z,
+                },
+            )?;
             graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
             graphics_record_command(graphics, DrawCommand::PopMatrix)?;
         } else {

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -50,7 +50,13 @@ fn sketch() -> error::Result<()> {
         )?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )?;
         graphics_record_command(graphics, DrawCommand::Material(mat))?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -50,7 +50,7 @@ fn sketch() -> error::Result<()> {
         )?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
         graphics_record_command(graphics, DrawCommand::Material(mat))?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -89,7 +89,7 @@ fn sketch() -> error::Result<()> {
         graphics_record_command(graphics, DrawCommand::Material(pbr_mat))?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -89,7 +89,13 @@ fn sketch() -> error::Result<()> {
         graphics_record_command(graphics, DrawCommand::Material(pbr_mat))?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )?;
         graphics_record_command(graphics, DrawCommand::Geometry(box_geo))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -86,7 +86,7 @@ fn sketch() -> error::Result<()> {
                     DrawCommand::Translate(Vec2::new(
                         col as f32 * spacing - offset_x,
                         row as f32 * spacing - offset_y,
-                    )),
+                    ).extend(0.0)),
                 )?;
                 graphics_record_command(graphics, DrawCommand::Material(mat))?;
                 graphics_record_command(graphics, DrawCommand::Geometry(sphere))?;

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -83,10 +83,13 @@ fn sketch() -> error::Result<()> {
                 graphics_record_command(graphics, DrawCommand::PushMatrix)?;
                 graphics_record_command(
                     graphics,
-                    DrawCommand::Translate(Vec2::new(
-                        col as f32 * spacing - offset_x,
-                        row as f32 * spacing - offset_y,
-                    ).extend(0.0)),
+                    DrawCommand::Translate(
+                        Vec2::new(
+                            col as f32 * spacing - offset_x,
+                            row as f32 * spacing - offset_y,
+                        )
+                        .extend(0.0),
+                    ),
                 )?;
                 graphics_record_command(graphics, DrawCommand::Material(mat))?;
                 graphics_record_command(graphics, DrawCommand::Geometry(sphere))?;

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -67,10 +67,13 @@ fn sketch() -> error::Result<()> {
                 graphics_record_command(graphics, DrawCommand::PushMatrix)?;
                 graphics_record_command(
                     graphics,
-                    DrawCommand::Translate(Vec2::new(
-                        col as f32 * spacing - offset_x,
-                        row as f32 * spacing - offset_y,
-                    ).extend(0.0)),
+                    DrawCommand::Translate(
+                        Vec2::new(
+                            col as f32 * spacing - offset_x,
+                            row as f32 * spacing - offset_y,
+                        )
+                        .extend(0.0),
+                    ),
                 )?;
                 graphics_record_command(
                     graphics,

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -70,7 +70,7 @@ fn sketch() -> error::Result<()> {
                     DrawCommand::Translate(Vec2::new(
                         col as f32 * spacing - offset_x,
                         row as f32 * spacing - offset_y,
-                    )),
+                    ).extend(0.0)),
                 )?;
                 graphics_record_command(
                     graphics,

--- a/examples/primitives_3d.rs
+++ b/examples/primitives_3d.rs
@@ -106,8 +106,17 @@ fn sketch() -> error::Result<()> {
 
         for (x_offset, make_cmd) in &shapes {
             graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-            graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(*x_offset, 0.0).extend(0.0)))?;
-            graphics_record_command(graphics, DrawCommand::Rotate { angle: t, axis: Vec3::Z })?;
+            graphics_record_command(
+                graphics,
+                DrawCommand::Translate(Vec2::new(*x_offset, 0.0).extend(0.0)),
+            )?;
+            graphics_record_command(
+                graphics,
+                DrawCommand::Rotate {
+                    angle: t,
+                    axis: Vec3::Z,
+                },
+            )?;
             graphics_record_command(graphics, make_cmd(t))?;
             graphics_record_command(graphics, DrawCommand::PopMatrix)?;
         }

--- a/examples/primitives_3d.rs
+++ b/examples/primitives_3d.rs
@@ -106,8 +106,8 @@ fn sketch() -> error::Result<()> {
 
         for (x_offset, make_cmd) in &shapes {
             graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-            graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(*x_offset, 0.0)))?;
-            graphics_record_command(graphics, DrawCommand::Rotate { angle: t })?;
+            graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(*x_offset, 0.0).extend(0.0)))?;
+            graphics_record_command(graphics, DrawCommand::Rotate { angle: t, axis: Vec3::Z })?;
             graphics_record_command(graphics, make_cmd(t))?;
             graphics_record_command(graphics, DrawCommand::PopMatrix)?;
         }

--- a/examples/stroke_3d.rs
+++ b/examples/stroke_3d.rs
@@ -35,8 +35,17 @@ fn sketch() -> error::Result<()> {
 
         // thin wireframe box
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(-80.0, 0.0).extend(0.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Translate(Vec2::new(-80.0, 0.0).extend(0.0)),
+        )?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle,
+                axis: Vec3::Z,
+            },
+        )?;
 
         graphics_record_command(
             graphics,
@@ -61,7 +70,13 @@ fn sketch() -> error::Result<()> {
         // thick wireframe box
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
         graphics_record_command(graphics, DrawCommand::Translate(Vec2::ZERO.extend(0.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.7, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle: angle * 0.7,
+                axis: Vec3::Z,
+            },
+        )?;
 
         graphics_record_command(
             graphics,
@@ -85,8 +100,17 @@ fn sketch() -> error::Result<()> {
 
         // thick wireframe sphere
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(80.0, 0.0).extend(0.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.5, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Translate(Vec2::new(80.0, 0.0).extend(0.0)),
+        )?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle: angle * 0.5,
+                axis: Vec3::Z,
+            },
+        )?;
 
         graphics_record_command(
             graphics,
@@ -110,7 +134,10 @@ fn sketch() -> error::Result<()> {
 
         // wireframe-only sphere (no fill)
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(160.0, 0.0).extend(0.0)))?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Translate(Vec2::new(160.0, 0.0).extend(0.0)),
+        )?;
         graphics_record_command(
             graphics,
             DrawCommand::Rotate {

--- a/examples/stroke_3d.rs
+++ b/examples/stroke_3d.rs
@@ -35,8 +35,8 @@ fn sketch() -> error::Result<()> {
 
         // thin wireframe box
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(-80.0, 0.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(-80.0, 0.0).extend(0.0)))?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
 
         graphics_record_command(
             graphics,
@@ -60,8 +60,8 @@ fn sketch() -> error::Result<()> {
 
         // thick wireframe box
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::ZERO))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.7 })?;
+        graphics_record_command(graphics, DrawCommand::Translate(Vec2::ZERO.extend(0.0)))?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.7, axis: Vec3::Z })?;
 
         graphics_record_command(
             graphics,
@@ -85,8 +85,8 @@ fn sketch() -> error::Result<()> {
 
         // thick wireframe sphere
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(80.0, 0.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.5 })?;
+        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(80.0, 0.0).extend(0.0)))?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle: angle * 0.5, axis: Vec3::Z })?;
 
         graphics_record_command(
             graphics,
@@ -110,11 +110,12 @@ fn sketch() -> error::Result<()> {
 
         // wireframe-only sphere (no fill)
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(160.0, 0.0)))?;
+        graphics_record_command(graphics, DrawCommand::Translate(Vec2::new(160.0, 0.0).extend(0.0)))?;
         graphics_record_command(
             graphics,
             DrawCommand::Rotate {
                 angle: -angle * 0.3,
+                axis: Vec3::Z,
             },
         )?;
 

--- a/examples/text_3d.rs
+++ b/examples/text_3d.rs
@@ -61,8 +61,8 @@ fn sketch() -> error::Result<()> {
         graphics_record_command(graphics, DrawCommand::Material(glow))?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Scale(Vec2::new(15.0, 15.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: t * 0.3 })?;
+        graphics_record_command(graphics, DrawCommand::Scale(Vec2::new(15.0, 15.0).extend(1.0)))?;
+        graphics_record_command(graphics, DrawCommand::Rotate { angle: t * 0.3, axis: Vec3::Z })?;
         graphics_record_command(graphics, DrawCommand::Geometry(geom))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/text_3d.rs
+++ b/examples/text_3d.rs
@@ -61,8 +61,17 @@ fn sketch() -> error::Result<()> {
         graphics_record_command(graphics, DrawCommand::Material(glow))?;
 
         graphics_record_command(graphics, DrawCommand::PushMatrix)?;
-        graphics_record_command(graphics, DrawCommand::Scale(Vec2::new(15.0, 15.0).extend(1.0)))?;
-        graphics_record_command(graphics, DrawCommand::Rotate { angle: t * 0.3, axis: Vec3::Z })?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Scale(Vec2::new(15.0, 15.0).extend(1.0)),
+        )?;
+        graphics_record_command(
+            graphics,
+            DrawCommand::Rotate {
+                angle: t * 0.3,
+                axis: Vec3::Z,
+            },
+        )?;
         graphics_record_command(graphics, DrawCommand::Geometry(geom))?;
         graphics_record_command(graphics, DrawCommand::PopMatrix)?;
 

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,6 +1,6 @@
 use processing_glfw::GlfwContext;
 
-use bevy::math::Vec2;
+use bevy::math::{Vec2, Vec3};
 use processing::prelude::*;
 use processing_render::render::command::DrawCommand;
 use std::f32::consts::PI;
@@ -36,14 +36,14 @@ fn sketch() -> error::Result<()> {
                     DrawCommand::Translate(Vec2::new(
                         50.0 + j as f32 * 100.0,
                         50.0 + i as f32 * 100.0,
-                    )),
+                    ).extend(0.0)),
                 )?;
 
                 let angle = t + (i + j) as f32 * PI / 8.0;
-                graphics_record_command(graphics, DrawCommand::Rotate { angle })?;
+                graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
 
                 let s = 0.8 + (t * 2.0 + (i * j) as f32).sin() * 0.2;
-                graphics_record_command(graphics, DrawCommand::Scale(Vec2::splat(s)))?;
+                graphics_record_command(graphics, DrawCommand::Scale(Vec2::splat(s).extend(1.0)))?;
 
                 let r = j as f32 / 3.0;
                 let g = i as f32 / 3.0;

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -33,14 +33,19 @@ fn sketch() -> error::Result<()> {
 
                 graphics_record_command(
                     graphics,
-                    DrawCommand::Translate(Vec2::new(
-                        50.0 + j as f32 * 100.0,
-                        50.0 + i as f32 * 100.0,
-                    ).extend(0.0)),
+                    DrawCommand::Translate(
+                        Vec2::new(50.0 + j as f32 * 100.0, 50.0 + i as f32 * 100.0).extend(0.0),
+                    ),
                 )?;
 
                 let angle = t + (i + j) as f32 * PI / 8.0;
-                graphics_record_command(graphics, DrawCommand::Rotate { angle, axis: Vec3::Z })?;
+                graphics_record_command(
+                    graphics,
+                    DrawCommand::Rotate {
+                        angle,
+                        axis: Vec3::Z,
+                    },
+                )?;
 
                 let s = 0.8 + (t * 2.0 + (i * j) as f32).sin() * 0.2;
                 graphics_record_command(graphics, DrawCommand::Scale(Vec2::splat(s).extend(1.0)))?;


### PR DESCRIPTION
We had some inconsistency about how we were handling rotation with explicit X/Y/Z versions. We should prefer the vec'd versions in our libprocessing apis and treat the x/y/z helpers as a higher level concern, this keeps things simple and is closer to the linalg which is fine for us to express in libprocessing rather than hiding. We also just assume 3d and expect 2d callers to do the sensible thing when calling. This makes things consistent with rotation and scale.