### PR TITLE
Fix panic in poll_for_sketch_updates when message system not initialized

### DIFF
--- a/crates/processing_render/src/lib.rs
+++ b/crates/processing_render/src/lib.rs
@@ -1480,7 +1480,8 @@ pub fn poll_for_sketch_updates() -> error::Result<Option<sketch::Sketch>> {
         Ok(app
             .world_mut()
             .run_system_cached(sketch::sketch_update_handler)
-            .unwrap())
+            .ok()
+            .flatten())
     })
 }
 


### PR DESCRIPTION
sketch_update_handler uses MessageReader<AssetEvent<Sketch>> which requires Bevy's message system to be initialized. When called via run_system_cached before the app is fully started, it returns SystemParamValidationError instead of a value, causing unwrap() to panic.

Fix: use .ok().flatten() to return None gracefully when the system isn't ready, matching the expected Option<Sketch> return type.

Fixes: thread panicked at crates/processing_render/src/lib.rs
  called Result::unwrap() on Err(Failed(SystemParamValidationError {
    message: "Message not initialized", field: "::messages" }))