### PR TITLE
Enable x11 feature by default for Linux X11 session support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ autoexamples = false
 workspace = true
 
 [features]
-default = ["wayland"]
+default = ["wayland", "x11"]
 wayland = ["processing_render/wayland"]
 x11 = ["processing_render/x11"]
 webcam = ["dep:processing_webcam"]


### PR DESCRIPTION
Add x11 to default features alongside wayland so mewnala works out of the box on X11-only sessions (i3, openbox, etc.) without requiring users to recompile with --features x11.

Previously mewnala would fail on X11 sessions with:
  GLFW Error: Wayland: Platform not initialized