### PR TITLE
Enable x11 feature by default in processing_pyo3

### DIFF
--- a/crates/processing_ffi/src/lib.rs
+++ b/crates/processing_ffi/src/lib.rs
@@ -2982,49 +2982,65 @@ pub extern "C" fn processing_filter_set_passes(filter_id: u64, passes: u32) {
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_blur() -> u64 {
     error::clear_error();
-    error::check(|| filter_blur()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_blur())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_invert() -> u64 {
     error::clear_error();
-    error::check(|| filter_invert()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_invert())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_gray() -> u64 {
     error::clear_error();
-    error::check(|| filter_gray()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_gray())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_threshold() -> u64 {
     error::clear_error();
-    error::check(|| filter_threshold()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_threshold())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_posterize() -> u64 {
     error::clear_error();
-    error::check(|| filter_posterize()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_posterize())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_opaque() -> u64 {
     error::clear_error();
-    error::check(|| filter_opaque()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_opaque())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_erode() -> u64 {
     error::clear_error();
-    error::check(|| filter_erode()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_erode())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn processing_filter_dilate() -> u64 {
     error::clear_error();
-    error::check(|| filter_dilate()).map(|e| e.to_bits()).unwrap_or(0)
+    error::check(|| filter_dilate())
+        .map(|e| e.to_bits())
+        .unwrap_or(0)
 }
 
 /// Create a shader from WGSL source.

--- a/crates/processing_pyo3/Cargo.toml
+++ b/crates/processing_pyo3/Cargo.toml
@@ -11,7 +11,7 @@ name = "mewnala"
 crate-type = ["cdylib"]
 
 [features]
-default = ["wayland", "static-link"]
+default = ["wayland", "x11", "static-link"]
 wayland = ["processing/wayland", "processing_glfw/wayland"]
 static-link = ["processing_glfw/static-link"]
 x11 = ["processing/x11", "processing_glfw/x11"]


### PR DESCRIPTION
The workspace Cargo.toml already enables x11 by default, but processing_pyo3 has its own default features that didn't include x11. This meant building with maturin from the sub-crate would produce a Wayland-only wheel even on X11 systems.

Add x11 to processing_pyo3's default features to match the workspace.