### PR TITLE
Update Rust examples

### DIFF
--- a/examples/animated_mesh.rs
+++ b/examples/animated_mesh.rs
@@ -19,12 +19,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 600)?;
+    let mut glfw_ctx = GlfwContext::new(600, 600, false)?;
     init(Config::default())?;
 
     let width = 600;
     let height = 600;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let grid_size = 20;

--- a/examples/background_image.rs
+++ b/examples/background_image.rs
@@ -17,12 +17,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
     let width = 400;
     let height = 400;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let image = image_load("images/logo.png")?;
 

--- a/examples/blend_modes.rs
+++ b/examples/blend_modes.rs
@@ -28,10 +28,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 500;
     let height = 500;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let mut index: usize = 0;

--- a/examples/box.rs
+++ b/examples/box.rs
@@ -18,12 +18,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
     let width = 400;
     let height = 400;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let box_geo = geometry_box(100.0, 100.0, 100.0)?;
 

--- a/examples/camera_controllers.rs
+++ b/examples/camera_controllers.rs
@@ -20,10 +20,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 800;
     let height = 600;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let box_geo = geometry_box(100.0, 100.0, 100.0)?;
 

--- a/examples/curves.rs
+++ b/examples/curves.rs
@@ -9,10 +9,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(800, 400)?;
+    let mut glfw_ctx = GlfwContext::new(800, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(800, 400)?;
+    let surface = glfw_ctx.create_surface(800, 400, false)?;
     let graphics = graphics_create(surface, 800, 400, TextureFormat::Rgba16Float)?;
 
     let mut t: f32 = 0.0;

--- a/examples/custom_attribute.rs
+++ b/examples/custom_attribute.rs
@@ -19,12 +19,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 600)?;
+    let mut glfw_ctx = GlfwContext::new(600, 600, false)?;
     init(Config::default())?;
 
     let width = 600;
     let height = 600;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let custom_attr = geometry_attribute_create("Custom", AttributeFormat::Float)?;

--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -20,10 +20,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 400;
     let height = 400;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let box_geo = geometry_box(100.0, 100.0, 100.0)?;
 

--- a/examples/filter.rs
+++ b/examples/filter.rs
@@ -19,10 +19,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(400, 400)?;
+    let surface = glfw_ctx.create_surface(400, 400, false)?;
     let graphics = graphics_create(surface, 400, 400, TextureFormat::Rgba16Float)?;
 
     let palette = [

--- a/examples/gltf_load.rs
+++ b/examples/gltf_load.rs
@@ -21,10 +21,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 800;
     let height = 600;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let gltf = gltf_load(graphics, "gltf/Duck.glb")?;

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -19,10 +19,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 400;
     let height = 400;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     while glfw_ctx.poll_events() {

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -18,12 +18,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
     let width = 400;
     let height = 400;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let box_geo = geometry_box(100.0, 100.0, 100.0)?;
     let pbr_mat = material_create_pbr()?;

--- a/examples/materials.rs
+++ b/examples/materials.rs
@@ -20,10 +20,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 800;
     let height = 600;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
     let sphere = geometry_sphere(30.0, 32, 18)?;
 

--- a/examples/midi.rs
+++ b/examples/midi.rs
@@ -44,10 +44,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(WIDTH, HEIGHT)?;
+    let mut glfw_ctx = GlfwContext::new(WIDTH, HEIGHT, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(WIDTH, HEIGHT)?;
+    let surface = glfw_ctx.create_surface(WIDTH, HEIGHT, false)?;
     let graphics = graphics_create(surface, WIDTH, HEIGHT, TextureFormat::Rgba16Float)?;
 
     midi_refresh_ports()?;

--- a/examples/particles_animated.rs
+++ b/examples/particles_animated.rs
@@ -34,10 +34,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_basic.rs
+++ b/examples/particles_basic.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_colored.rs
+++ b/examples/particles_colored.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_colored_pbr.rs
+++ b/examples/particles_colored_pbr.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_emit.rs
+++ b/examples/particles_emit.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_emit_gpu.rs
+++ b/examples/particles_emit_gpu.rs
@@ -120,10 +120,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_from_mesh.rs
+++ b/examples/particles_from_mesh.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_lifecycle.rs
+++ b/examples/particles_lifecycle.rs
@@ -47,10 +47,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_noise.rs
+++ b/examples/particles_noise.rs
@@ -11,10 +11,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_oriented.rs
+++ b/examples/particles_oriented.rs
@@ -45,10 +45,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_scatter.rs
+++ b/examples/particles_scatter.rs
@@ -40,10 +40,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_scatter_volume.rs
+++ b/examples/particles_scatter_volume.rs
@@ -40,10 +40,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 400)?;
+    let mut glfw_ctx = GlfwContext::new(600, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_stress.rs
+++ b/examples/particles_stress.rs
@@ -48,10 +48,10 @@ fn hash_unit(seed: u32) -> f32 {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 700)?;
+    let mut glfw_ctx = GlfwContext::new(900, 700, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 700)?;
+    let surface = glfw_ctx.create_surface(900, 700, false)?;
     let graphics = graphics_create(surface, 900, 700, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/particles_text_whirl.rs
+++ b/examples/particles_text_whirl.rs
@@ -261,10 +261,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(1200, 800)?;
+    let mut glfw_ctx = GlfwContext::new(1200, 800, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(1200, 800)?;
+    let surface = glfw_ctx.create_surface(1200, 800, false)?;
     let graphics = graphics_create(surface, 1200, 800, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -20,10 +20,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 800;
     let height = 600;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/primitives_2d.rs
+++ b/examples/primitives_2d.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 600)?;
+    let mut glfw_ctx = GlfwContext::new(600, 600, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(600, 600)?;
+    let surface = glfw_ctx.create_surface(600, 600, false)?;
     let graphics = graphics_create(surface, 600, 600, TextureFormat::Rgba16Float)?;
 
     let mut t: f32 = 0.0;

--- a/examples/primitives_3d.rs
+++ b/examples/primitives_3d.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(900, 400)?;
+    let mut glfw_ctx = GlfwContext::new(900, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(900, 400)?;
+    let surface = glfw_ctx.create_surface(900, 400, false)?;
     let graphics = graphics_create(surface, 900, 400, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/rectangle.rs
+++ b/examples/rectangle.rs
@@ -17,12 +17,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
     let width = 400;
     let height = 400;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     while glfw_ctx.poll_events() {

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 600)?;
+    let mut glfw_ctx = GlfwContext::new(600, 600, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(600, 600)?;
+    let surface = glfw_ctx.create_surface(600, 600, false)?;
     let graphics = graphics_create(surface, 600, 600, TextureFormat::Rgba16Float)?;
 
     let mut t: f32 = 0.0;

--- a/examples/stroke_2d.rs
+++ b/examples/stroke_2d.rs
@@ -9,10 +9,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 300)?;
+    let mut glfw_ctx = GlfwContext::new(600, 300, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(600, 300)?;
+    let surface = glfw_ctx.create_surface(600, 300, false)?;
     let graphics = graphics_create(surface, 600, 300, TextureFormat::Rgba16Float)?;
 
     let joins = [

--- a/examples/stroke_3d.rs
+++ b/examples/stroke_3d.rs
@@ -10,10 +10,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 400)?;
+    let mut glfw_ctx = GlfwContext::new(600, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(600, 400)?;
+    let surface = glfw_ctx.create_surface(600, 400, false)?;
     let graphics = graphics_create(surface, 600, 400, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -18,12 +18,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(600, 400)?;
+    let mut glfw_ctx = GlfwContext::new(600, 400, false)?;
     init(Config::default())?;
 
     let width = 600;
     let height = 400;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     while glfw_ctx.poll_events() {

--- a/examples/text_3d.rs
+++ b/examples/text_3d.rs
@@ -12,10 +12,10 @@ fn main() {
 fn sketch() -> error::Result<()> {
     let width = 1200;
     let height = 700;
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     graphics_mode_3d(graphics)?;

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -11,10 +11,10 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(400, 400)?;
+    let mut glfw_ctx = GlfwContext::new(400, 400, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(400, 400)?;
+    let surface = glfw_ctx.create_surface(400, 400, false)?;
     let graphics = graphics_create(surface, 400, 400, TextureFormat::Rgba16Float)?;
 
     let mut t: f32 = 0.0;

--- a/examples/update_pixels.rs
+++ b/examples/update_pixels.rs
@@ -17,12 +17,12 @@ fn main() {
 }
 
 fn sketch() -> error::Result<()> {
-    let mut glfw_ctx = GlfwContext::new(100, 100)?;
+    let mut glfw_ctx = GlfwContext::new(100, 100, false)?;
     init(Config::default())?;
 
     let width = 100;
     let height = 100;
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let rect_w = 10;

--- a/examples/webcam.rs
+++ b/examples/webcam.rs
@@ -21,10 +21,10 @@ fn sketch() -> error::Result<()> {
     let width = 640;
     let height = 480;
 
-    let mut glfw_ctx = GlfwContext::new(width, height)?;
+    let mut glfw_ctx = GlfwContext::new(width, height, false)?;
     init(Config::default())?;
 
-    let surface = glfw_ctx.create_surface(width, height)?;
+    let surface = glfw_ctx.create_surface(width, height, false)?;
     let graphics = graphics_create(surface, width, height, TextureFormat::Rgba16Float)?;
 
     let webcam = webcam_create()?;


### PR DESCRIPTION
Rust examples now matches new Glfw and create_surface API

Please note i haven't manually tested all the examples, only a few of them, but my regexs should have caught every previous 2-params calls for `GlfwContext::new()` and `glfw_ctx.create_surface()`.